### PR TITLE
Feature/ws 1802 fix query generation with more complex or statements

### DIFF
--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -548,9 +548,11 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     let params = {};
     if (obj.keyQuery) {
       queryParams.KeyConditionExpression = me.generateExpression(params, obj.keyQuery);
+      console.log(obj.keyQuery);
     }
     if (obj.filterQuery) {
       queryParams.FilterExpression = me.generateExpression(params, obj.filterQuery);
+      console.log(obj.filterQuery);
     }
 
     if (obj.keyQuery || obj.filterQuery) {
@@ -631,6 +633,8 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
       cb();
     });
   }
+
+  console.log(queryParams);
 
   runQuery(queryParams, function (err) {
     if (err) {
@@ -1459,33 +1463,87 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
     return returnExpression;
   }
 
+  let analyzeAndOr = (params, conditionValue, operator) => {
+    let returnExpressions = [];
+    //let properties = Object.keys(conditionValue);
+    conditionValue.forEach((obj) => {
+      let key = Object.keys(obj)[0];
+      let value = obj[key];
+      if (key === 'and') {
+        returnExpressions.push(analyzeAndOr(params, value, ' AND '));
+      } else if (key === 'or') {
+        returnExpressions.push(analyzeAndOr(params, value, ' OR '));
+      } else {
+        console.log(key);
+        console.log(value);
+        console.log(addExpressionToParam(params, key, value));
+        returnExpressions.push(addExpressionToParam(params, key, value));
+      }
+    });
+
+    console.log(returnExpressions.length);
+    if (returnExpressions.length > 1) {
+      return '(' + returnExpressions.join(operator) + ')';
+    } else {
+      return returnExpressions[0];
+    }
+  }
+
   let analyzeQueryWhere = (params, queryWhere) => {
-    let returnExpression = '';
+    //let returnExpression = '';
+    let returnExpressions = [];
     let properties = Object.keys(queryWhere);
     properties.forEach((key) => {
       let conditionValue = queryWhere[key];
       if (key === 'and') {
-        let returnExpressions = [];
-        conditionValue.forEach((whereClause) => {
-          returnExpressions.push(analyzeQueryWhere(params, whereClause));
-        });
-        returnExpression += returnExpressions.join(' AND ');
+        returnExpressions.push(analyzeAndOr(params, conditionValue, ' AND '));
+        // let returnExpressions = [];
+        // conditionValue.forEach((whereClause) => {
+        //   returnExpressions.push(analyzeQueryWhere(params, whereClause));
+        // });
+
+        // if (returnExpression !== '') {
+        //   returnExpression += ' AND ';
+        // }
+
+        // if (returnExpressions.length > 1) {
+        //   returnExpression += '(' + returnExpressions.join(' AND ') + ')';
+        // } else {
+        //   returnExpression += returnExpressions[0];
+        // }
       } else if (key === 'or') {
-        let returnExpressions = [];
-        conditionValue.forEach((whereClause) => {
-          returnExpressions.push(analyzeQueryWhere(params, whereClause));
-        });
-        returnExpression += returnExpressions.join(' OR ');
+        console.log(conditionValue);
+        returnExpressions.push(analyzeAndOr(params, conditionValue, ' OR '));
+        // let returnExpressions = [];
+        // conditionValue.forEach((whereClause) => {
+        //   returnExpressions.push(analyzeQueryWhere(params, whereClause));
+        // });
+
+        // if (returnExpression !== '') {
+        //   returnExpression += ' AND ';
+        // }
+
+        // if (returnExpressions.length > 1) {
+        //   returnExpression += '(' + returnExpressions.join(' OR ') + ')';
+        // } else {
+        //   returnExpression += returnExpressions[0];
+        // }
       } else {
-        if (returnExpression !== '') {
-          // concadenate with ' AND '
-          returnExpression = returnExpression + ' AND ' + addExpressionToParam(params, key, conditionValue);
-        } else {
-          returnExpression = addExpressionToParam(params, key, conditionValue);
-        }
+        returnExpressions.push(addExpressionToParam(params, key, conditionValue));
+        // if (returnExpression !== '') {
+        //   // concadenate with ' AND '
+        //   returnExpression += ' AND ' + addExpressionToParam(params, key, conditionValue);
+        //   //console.log("new returnExpression is " + returnExpression);
+        // } else {
+        //   returnExpression = addExpressionToParam(params, key, conditionValue);
+        // }
+        //console.log("new returnExpression is " + returnExpression);
       }
     });
-    return returnExpression;
+    
+    //console.log('returnExpression is now ' + returnExpression);
+    //return returnExpression;
+    return returnExpressions.join(' AND ');
   }
   return analyzeQueryWhere(params, queryWhere);
 }

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -541,43 +541,21 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     cb = filter;
   }
 
-  // let obj = me.splitWhere(index, filter.where);
-  // let keyQuery = obj.keyQuery;
-  // let filterQuery = obj.filterQuery;
-  // // console.log(keyQuery);
-  // // console.log(filterQuery);
-
-  // // get both KeyConditionExpression and FilterExpression
-  // // also need ExpressionAttributeNames and ExpressionAttributeValues
-
-  // let params = {};
-  // let keyConditionExpression = me.generateExpression(params, keyQuery);
-  // //let keyConditionExpression = params.Expression;
-  // let filterExpression = me.generateExpression(params, filterQuery);
-  // let expressionAttributeNames = params.ExpressionAttributeNames;
-  // let expressionAttributeValues = params.ExpressionAttributeValues;
-
-  // console.log('KeyConditionExpression');
-  // console.log(keyConditionExpression);
-  // console.log('FilterExpression');
-  // console.log(filterExpression);
-  // console.log('ExpressionAttributeNames');
-  // console.log(expressionAttributeNames);
-  // console.log('ExpressionAttributeValues');
-  // console.log(expressionAttributeValues);
-
-
   queryParams.TableName = this.tableName(model);
 
   if (properties) {
     let obj = me.splitWhere(index, filter.where);
     let params = {};
-    queryParams.KeyConditionExpression = me.generateExpression(params, obj.keyQuery);
-    queryParams.FilterExpression = me.generateExpression(params, obj.filterQuery);
+    if (obj.keyQuery) {
+      queryParams.KeyConditionExpression = me.generateExpression(params, obj.keyQuery);
+    }
+    if (obj.filterQuery) {
+      queryParams.FilterExpression = me.generateExpression(params, obj.filterQuery);
+    }
     queryParams.ExpressionAttributeNames = params.ExpressionAttributeNames;
     queryParams.ExpressionAttributeValues = params.ExpressionAttributeValues;
 
-    if (queryParams.KeyConditionExpression === '') {
+    if (!queryParams.KeyConditionExpression || queryParams.KeyConditionExpression === '') {
       findOperation = 'scan';
     }
   }
@@ -695,13 +673,20 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
   });
 };
 
+/**
+ * @param {Array}     index         The index return from findIndex()
+ * @param {Object}    whereObject   filter.where
+ * return {Object}                  returns an object containing fileds keyQuery and filterQuery, where keyQuery is the whereObject 
+ *                                  to be used to generate KeyConditionExpression and filterQuery is the whereObject to be used to 
+ *                                  generate FilterExpression
+ */
 DynamoDB.prototype.splitWhere = (index, whereObject) => {
-
   /**
    * @param {String}  key               The key in the where clause, either a property of the model, or a logical operator (and/or)
    * @param {String}  operator          The operator the key is query on (e.g., 'lt', 'gt', 'between', 'eq', 'inq', etc.)
    * @param {Array}   conditionValue    The condition the operator operates on
    * @param {Object}  index             Index object
+   * return {Boolean}                   Return if the given key can be query with key (true), or has to be part of the FilterExpression
    */
   let isIndexed = (key, operator, conditionValue, index) => {
     if (!index) {
@@ -1392,6 +1377,10 @@ DynamoDB.prototype.range = function (model, id, start, end, callback) {
  * takes the queryWhere (the splited where object), 
  * add params object with ExpressionAttributeNames, and ExpressionAttributeValues
  * return object with Expression (either KeyConditionExpression or FilterExpression)
+ * 
+ * @params {Object}   params          hold ExpressionAttributeNames and ExpressionAttributeValues
+ * @params {Object}   queryWhere      the query whereObject from splitWhere, either keyQuery or filterQuery
+ * return  {String}                   return the Expression string, either KeyConditionExpression or FilterExpression (determined by caller)
  */
 DynamoDB.prototype.generateExpression = (params, queryWhere) => {
 
@@ -1510,14 +1499,6 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
             returnExpression = analyzeQueryWhere(params, whereClause);
           }
         });
-        // conditionValue.forEach((whereClause) => {
-        //   let expression = params.Expression;
-        //   console.log(whereClause);
-        //   analyzeQueryWhere(params, whereClause);
-        //   if (expression !== '') {
-        //     params.Expression = expression + ' AND ' + params.Expression;
-        //   }
-        // });
       } else if (key === 'or') {
         conditionValue.forEach((whereClause) => {
           if (returnExpression !== '') {
@@ -1526,16 +1507,6 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
             returnExpression = analyzeQueryWhere(params, whereClause);
           }
         });
-
-
-        // conditionValue.forEach((whereClause) => {
-        //   let expression = params.Expression;
-        //   console.log(whereClause);
-        //   analyzeQueryWhere(params, whereClause);
-        //   if (expression !== '') {
-        //     params.Expression = expression + ' OR ' + params.Expression;
-        //   }
-        // });
       } else {
         if (returnExpression !== '') {
           // concadenate with ' AND '

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -548,11 +548,9 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     let params = {};
     if (obj.keyQuery) {
       queryParams.KeyConditionExpression = me.generateExpression(params, obj.keyQuery);
-      console.log(obj.keyQuery);
     }
     if (obj.filterQuery) {
       queryParams.FilterExpression = me.generateExpression(params, obj.filterQuery);
-      console.log(obj.filterQuery);
     }
 
     if (obj.keyQuery || obj.filterQuery) {
@@ -633,8 +631,6 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
       cb();
     });
   }
-
-  console.log(queryParams);
 
   runQuery(queryParams, function (err) {
     if (err) {
@@ -1465,7 +1461,6 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
 
   let analyzeAndOr = (params, conditionValue, operator) => {
     let returnExpressions = [];
-    //let properties = Object.keys(conditionValue);
     conditionValue.forEach((obj) => {
       let key = Object.keys(obj)[0];
       let value = obj[key];
@@ -1474,14 +1469,10 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
       } else if (key === 'or') {
         returnExpressions.push(analyzeAndOr(params, value, ' OR '));
       } else {
-        console.log(key);
-        console.log(value);
-        console.log(addExpressionToParam(params, key, value));
         returnExpressions.push(addExpressionToParam(params, key, value));
       }
     });
 
-    console.log(returnExpressions.length);
     if (returnExpressions.length > 1) {
       return '(' + returnExpressions.join(operator) + ')';
     } else {
@@ -1490,59 +1481,19 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
   }
 
   let analyzeQueryWhere = (params, queryWhere) => {
-    //let returnExpression = '';
     let returnExpressions = [];
     let properties = Object.keys(queryWhere);
     properties.forEach((key) => {
       let conditionValue = queryWhere[key];
       if (key === 'and') {
         returnExpressions.push(analyzeAndOr(params, conditionValue, ' AND '));
-        // let returnExpressions = [];
-        // conditionValue.forEach((whereClause) => {
-        //   returnExpressions.push(analyzeQueryWhere(params, whereClause));
-        // });
-
-        // if (returnExpression !== '') {
-        //   returnExpression += ' AND ';
-        // }
-
-        // if (returnExpressions.length > 1) {
-        //   returnExpression += '(' + returnExpressions.join(' AND ') + ')';
-        // } else {
-        //   returnExpression += returnExpressions[0];
-        // }
       } else if (key === 'or') {
-        console.log(conditionValue);
         returnExpressions.push(analyzeAndOr(params, conditionValue, ' OR '));
-        // let returnExpressions = [];
-        // conditionValue.forEach((whereClause) => {
-        //   returnExpressions.push(analyzeQueryWhere(params, whereClause));
-        // });
-
-        // if (returnExpression !== '') {
-        //   returnExpression += ' AND ';
-        // }
-
-        // if (returnExpressions.length > 1) {
-        //   returnExpression += '(' + returnExpressions.join(' OR ') + ')';
-        // } else {
-        //   returnExpression += returnExpressions[0];
-        // }
       } else {
         returnExpressions.push(addExpressionToParam(params, key, conditionValue));
-        // if (returnExpression !== '') {
-        //   // concadenate with ' AND '
-        //   returnExpression += ' AND ' + addExpressionToParam(params, key, conditionValue);
-        //   //console.log("new returnExpression is " + returnExpression);
-        // } else {
-        //   returnExpression = addExpressionToParam(params, key, conditionValue);
-        // }
-        //console.log("new returnExpression is " + returnExpression);
       }
     });
     
-    //console.log('returnExpression is now ' + returnExpression);
-    //return returnExpression;
     return returnExpressions.join(' AND ');
   }
   return analyzeQueryWhere(params, queryWhere);

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -740,19 +740,24 @@ DynamoDB.prototype.splitWhere = function (index, whereObject) {
         }
       } else {
         if (Object.prototype.toString.call(conditionValue) == '[object Object]') {
+          var temp;
           var operators = Object.keys(conditionValue);
           operators.forEach(function (operator) {
             if (isIndexed(key, operator, conditionValue[operator], index)) {
               obj.keyQuery = obj.keyQuery || {};
               if (!obj.keyQuery[key]) {
-                obj.keyQuery[key] = { [operator]: conditionValue[operator] };
+                temp = {};
+                temp[operator] = conditionValue[operator];
+                obj.keyQuery[key] = temp;
               } else {
                 obj.keyQuery[key][operator] = conditionValue[operator];
               }
             } else {
               obj.filterQuery = obj.filterQuery || {};
               if (!obj.filterQuery[key]) {
-                obj.filterQuery[key] = { [operator]: conditionValue[operator] };
+                temp = {};
+                temp[operator] = conditionValue[operator];
+                obj.filterQuery[key] = temp;
               } else {
                 obj.filterQuery[key][operator] = conditionValue[operator];
               }

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -548,36 +548,49 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     let params = {};
     if (obj.keyQuery) {
       queryParams.KeyConditionExpression = me.generateExpression(params, obj.keyQuery);
+    } else {
+      console.log('no keyQuery');
     }
     if (obj.filterQuery) {
       queryParams.FilterExpression = me.generateExpression(params, obj.filterQuery);
+    } else {
+      console.log('no filterQuery');
     }
     queryParams.ExpressionAttributeNames = params.ExpressionAttributeNames;
     queryParams.ExpressionAttributeValues = params.ExpressionAttributeValues;
 
     if (!queryParams.KeyConditionExpression || queryParams.KeyConditionExpression === '') {
       findOperation = 'scan';
+      console.log('findOperation is scan');
     }
   }
+
+  // console.log(queryParams);
 
   // if (properties) {
   //   //console.log('before: ' + queryParams[1]);
   //   me.addWhereObjectToConditions(queryParams, index, filter.where);
   //   //console.log('after: ' + queryParams[1]);
   //   //console.log(queryParams);
-  //   me.splitWhere(index, filter.where);
+  //   //me.splitWhere(index, filter.where);
     
   //   if (!queryParams.KeyConditions) {
   //     findOperation = "scan";
+  //     console.log('find operation is scan');
   //   }
   // }
 
-  //console.log(queryParams);
+
+  // console.log(queryParams);
+  // console.log(queryParams.KeyConditions[0]);
+  //queryParams.KeyConditions = null
 
   if (order && findOperation === "query") {
     if (order[1] === 'ASC') {
+      console.log("forward true");
       queryParams.ScanIndexForward = true;
     } else {
+      console.log('forward false');
       queryParams.ScanIndexForward = false;
     }
   }
@@ -595,11 +608,17 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
       });
     }
 
-    queryParams.AttributesToGet = fieldsToInclude;
+    //queryParams.AttributesToGet = fieldsToInclude;
+    if (fieldsToInclude.length > 0) {
+      queryParams.ProjectionExpression = fieldsToInclude[0];
 
+      for (let i = 1; i < fieldsToInclude.length; i++) {
+        queryParams.ProjectionExpression += ', ' + fieldsToInclude[i];
+      }
+    }
   }
 
-  if (findOperation === "scan" && !queryParams.AttributesToGet) {
+  if (findOperation === "scan" && !queryParams.ProjectionExpression) {
     queryParams.Select = 'ALL_ATTRIBUTES';
   }
 
@@ -608,6 +627,7 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
   }
 
   function runQuery(params, cb) {
+    console.log('runQuery');
     if (filter.limit) {
       var max = filter.skip ? filter.limit + filter.skip : filter.limit;
       if (items.length >= max) {
@@ -617,7 +637,9 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     }
     debug && debug(params);
     me.client[findOperation](params, function (err, data) {
+      console.log('me.client[findOperation] cb');
       if (err) {
+        console.log(err);
         debug.enabled && debug(err,params);
         cb(err);
         return;
@@ -637,6 +659,8 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
       cb();
     });
   }
+
+  console.log(queryParams);
 
   runQuery(queryParams, function (err) {
     if (err) {
@@ -1355,6 +1379,7 @@ DynamoDB.prototype.convertFilter = function convertFilter(model, filter) {
 
 // TODO: wrap this functionality in with the main .all implementation
 DynamoDB.prototype.range = function (model, id, start, end, callback) {
+  console.log("range function called");
   var properties = this.getPrimaryKeyProperties(model);
   var hash = properties[0], range = properties[1];
   if(!hash.isHash) hash = properties[1], range = properties[0];

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -524,15 +524,22 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
 
   // promote top level AND
   if (filter.where && filter.where.and) {
+    let newWhere = {};
     filter.where.and.forEach((obj) => {
       let key = Object.keys(obj)[0];
       properties.push(key);
-      filter.where[key] = obj[key];
+      newWhere[key] = obj[key];
     });
 
     properties.splice(properties.indexOf('and'), 1);
-    delete filter.where.and;
+    // delete filter.where.and;
+    filter.where = newWhere;
   }
+
+  console.log("properties");
+  console.log(properties);
+  console.log("where");
+  console.log(filter.where);
 
   if (properties) {
     // console.log(properties);
@@ -785,7 +792,8 @@ DynamoDB.prototype.splitWhere = (index, whereObject, operator) => {
 
     return obj;
   }
-  
+  console.log("index");
+  console.log(index);
 
   let obj = analyzeWhereObject(index, whereObject, operator);
   console.log(whereObject);

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -521,7 +521,8 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
   // } else {
   //   console.log("non exist");
   // }
-  
+
+  // promote top level AND
   if (filter.where && filter.where.and) {
     filter.where.and.forEach((obj) => {
       let key = Object.keys(obj)[0];
@@ -534,8 +535,8 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
   }
 
   if (properties) {
-    console.log(properties);
-    console.log(filter.where);
+    // console.log(properties);
+    // console.log(filter.where);
     index = me.findIndex(properties, order && order[0], model);
   }
 
@@ -551,11 +552,17 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
   queryParams.TableName = this.tableName(model);
 
   if (properties) {
+    //console.log('before: ' + queryParams[1]);
     me.addWhereObjectToConditions(queryParams, index, filter.where);
+    //console.log('after: ' + queryParams[1]);
+    console.log(queryParams);
+    
     if (!queryParams.KeyConditions) {
       findOperation = "scan";
     }
   }
+
+  //console.log(queryParams);
 
   if (order && findOperation === "query") {
     if (order[1] === 'ASC') {
@@ -1246,6 +1253,114 @@ DynamoDB.prototype.range = function (model, id, start, end, callback) {
     else callback(null, data.Items);
   });
 };
+
+
+
+/**
+ * @private
+ * 
+ * return an object with Expression, ExpressionAttributeNames, and ExpressionAttributeValues
+ */
+DynamoDB.prototype.generateExpression = (key, conditionValue, operator) => { // TODO: need to take in params
+  if (key === "and") {
+    throw new Error("And operator not currently supported");
+  }
+
+  if (key === "or") {
+    throw new Error("Or operator not currently supported");
+  }
+
+  let returnObject = {};
+  returnObject.Expression = "";
+  returnObject.ExpressionAttributeNames = {};
+  returnObject.ExpressionAttributeValues = {};
+
+  let attributeShorthand = "#" + key;
+
+  let prepExpression = () => {
+    if (returnObject.Expression !== "") {
+      returnObject.Expression += " " + operator + " "; // TODO: operator
+    }
+
+    returnObject.ExpressionAttributeNames[attributeShorthand] = key;
+  }
+
+  let getExpressionValueToken = (value) => {
+    if (!util.isArray(value)) {
+      var token = value ? ":" + value.toString().replace(/[^a-zA-Z0-9]/g, "") : ":" + value;
+
+      if (value === "*") {
+        token = ":specialStarParamKey";
+      }
+
+      if (!returnObject.ExpressionAttributeValues[token]) {
+        if (value instanceof Date) {
+          returnObject.ExpressionAttributeValues[token] = value / 1;
+        } else {
+          returnObject.ExpressionAttributeValues[token] = value;
+        }
+      }
+      return token;
+    } else {
+      var tokens = [];
+      value.forEach(function (subValue) {
+        tokens.push(getExpressionValueToken(subValue));
+      });
+      return tokens.join(',');
+    }
+  }
+
+
+  if (Object.prototype.toString.call(conditionValue) == "[object Object]") {
+    let operators = Object.keys(conditionValue);
+    operators.forEach((keyValue) => {
+      //var useIndex = isIndexed(key, keyValue, conditionValue[keyValue], index);
+      prepExpression();
+      switch (keyValue) {
+        case 'inq':
+            returnObject.Expression += "(#" + key + " IN (" + getExpressionValueToken(conditionValue.inq) + ")" + ")";
+          break;
+        case 'gt':
+            returnObject.Expression += "(#" + key + " > " + getExpressionValueToken(conditionValue.gt) + ")";
+          break;
+        case 'gte':
+            returnObject.Expression += "(#" + key + " >= " + getExpressionValueToken(conditionValue.gte) + ")";
+          break;
+        case 'lt':
+            returnObject.Expression += "(#" + key + " < " + getExpressionValueToken(conditionValue.lt) + ")";
+          break;
+        case 'lte':
+            returnObject.Expression += "(#" + key + " <= " + getExpressionValueToken(conditionValue.lte) + ")";
+          break;
+        case 'between':
+            returnObject.Expression += "(#" + key + " BETWEEN " + getExpressionValueToken(conditionValue.between[0]) + " AND " + getExpressionValueToken(conditionValue.between[1]) + ")";
+          break;
+        case 'nin':
+            returnObject.Expression += "NOT " + "(#" + key + " IN (" + getExpressionValueToken(conditionValue.nin) + "))"
+            break;
+        case 'near':
+            throw new Error('near is not supported');
+        case 'neq':
+            returnObject.Expression += "(#" + key + " <> " + getExpressionValueToken(conditionValue.neq) + ")";
+            break;
+        case 'like':
+            returnObject.Expression += "(contains(#" + key + "," + getExpressionValueToken(conditionValue.like) + "))";
+            break;
+        case 'nlike':
+            returnObject.Expression += "(NOT contains(#" + key + "," + getExpressionValueToken(conditionValue.nlike) + "))";
+            break;
+        case 'or':
+        case 'and':
+            throw new Error('and and or conditions are not supported');
+      }
+    });
+  } else {
+    //Simple case -- do equivalency in query/scan notation.
+    prepExpression();
+    returnObject.Expression += "#" + key + " = " + getExpressionValueToken(conditionValue);
+  }
+}
+
 
 
 /**

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -514,14 +514,6 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     order = filter.order.split(' ');
   }
 
-  // if filter.where.AND key, move the array out
-  // let testVar = null;
-  // if (testVar && testVar.testField) {
-  //   console.log("exist");
-  // } else {
-  //   console.log("non exist");
-  // }
-
   // promote top level AND
   if (filter.where && filter.where.and) {
     let newWhere = {};
@@ -549,12 +541,20 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     cb = filter;
   }
 
-  let obj = this.splitWhere(index, filter.where);
+  let obj = me.splitWhere(index, filter.where);
   let keyQuery = obj.keyQuery;
   let filterQuery = obj.filterQuery;
   console.log(keyQuery);
   console.log(filterQuery);
 
+  // get both KeyConditionExpression and FilterExpression
+  // also need ExpressionAttributeNames and ExpressionAttributeValues
+
+  let params = {};
+  let keyConditionExpression = me.generateExpression(params, keyQuery);
+  console.log(keyConditionExpression);
+  console.log(params.ExpressionAttributeNames);
+  console.log(params.ExpressionAttributeValues);
 
 
   queryParams.TableName = this.tableName(model);
@@ -1365,6 +1365,138 @@ DynamoDB.prototype.range = function (model, id, start, end, callback) {
   });
 };
 
+/**
+ * takes the queryWhere (the splited where object), 
+ * add params object with ExpressionAttributeNames, and ExpressionAttributeValues
+ * return object with Expression (either KeyConditionExpression or FilterExpression)
+ */
+DynamoDB.prototype.generateExpression = (params, queryWhere) => {
+
+  /**
+   * @param {Object}  params          hold ExpressionAttributeNames and ExpressionAttributeValues
+   * @param {String}  key             The key in the where clause, either a property of the model, or a logical operator (and/or)
+   * @param {String}  conditionValue  The condition that the key operates on
+   * @param {String}  operator        'AND' or 'OR'
+   */
+  let addExpressionToParam = (params, key, conditionValue, operator) => { // TODO: need to take in params
+    if (key === "and") {
+      throw new Error("And operator not currently supported");
+    }
+
+    if (key === "or") {
+      throw new Error("Or operator not currently supported");
+    }
+
+    let returnExpression = "";
+    params.ExpressionAttributeNames = params.ExpressionAttributeNames || {};
+    params.ExpressionAttributeValues = params.ExpressionAttributeValues || {};
+
+    let attributeShorthand = "#" + key;
+
+    let prepExpressionAndAttributeName = () => {
+      if (returnExpression !== "") {
+        returnExpression += " " + operator + " "; // TODO: operator
+      }
+
+      params.ExpressionAttributeNames[attributeShorthand] = key;
+    }
+
+    let getExpressionValueToken = (value) => {
+      if (!util.isArray(value)) {
+        var token = value ? ":" + value.toString().replace(/[^a-zA-Z0-9]/g, "") : ":" + value;
+
+        if (value === "*") {
+          token = ":specialStarParamKey";
+        }
+
+        if (!params.ExpressionAttributeValues[token]) {
+          if (value instanceof Date) {
+            params.ExpressionAttributeValues[token] = value / 1;
+          } else {
+            params.ExpressionAttributeValues[token] = value;
+          }
+        }
+        return token;
+      } else {
+        var tokens = [];
+        value.forEach(function (subValue) {
+          tokens.push(getExpressionValueToken(subValue));
+        });
+        return tokens.join(',');
+      }
+    }
+
+
+    if (Object.prototype.toString.call(conditionValue) == "[object Object]") {
+      let operators = Object.keys(conditionValue);
+      operators.forEach((keyValue) => {
+        //var useIndex = isIndexed(key, keyValue, conditionValue[keyValue], index);
+        prepExpressionAndAttributeName();
+        switch (keyValue) {
+          case 'inq':
+              returnExpression += "(#" + key + " IN (" + getExpressionValueToken(conditionValue.inq) + ")" + ")";
+            break;
+          case 'gt':
+              returnExpression += "(#" + key + " > " + getExpressionValueToken(conditionValue.gt) + ")";
+            break;
+          case 'gte':
+              returnExpression += "(#" + key + " >= " + getExpressionValueToken(conditionValue.gte) + ")";
+            break;
+          case 'lt':
+              returnExpression += "(#" + key + " < " + getExpressionValueToken(conditionValue.lt) + ")";
+            break;
+          case 'lte':
+              returnExpression += "(#" + key + " <= " + getExpressionValueToken(conditionValue.lte) + ")";
+            break;
+          case 'between':
+              returnExpression += "(#" + key + " BETWEEN " + getExpressionValueToken(conditionValue.between[0]) + " AND " + getExpressionValueToken(conditionValue.between[1]) + ")";
+            break;
+          case 'nin':
+              returnExpression += "NOT " + "(#" + key + " IN (" + getExpressionValueToken(conditionValue.nin) + "))"
+              break;
+          case 'near':
+              throw new Error('near is not supported');
+          case 'neq':
+              returnExpression += "(#" + key + " <> " + getExpressionValueToken(conditionValue.neq) + ")";
+              break;
+          case 'like':
+              returnExpression += "(contains(#" + key + "," + getExpressionValueToken(conditionValue.like) + "))";
+              break;
+          case 'nlike':
+              returnExpression += "(NOT contains(#" + key + "," + getExpressionValueToken(conditionValue.nlike) + "))";
+              break;
+          case 'or':
+          case 'and':
+              throw new Error('and and or conditions are not supported');
+        }
+      });
+    } else {
+      //Simple case -- do equivalency in query/scan notation.
+      prepExpressionAndAttributeName();
+      returnExpression += "#" + key + " = " + getExpressionValueToken(conditionValue);
+    }
+  }
+
+  let analyzeQueryWhere = (params, queryWhere) => {
+    let returnExpression = "";
+    let properties = Object.keys(queryWhere);
+    properties.forEach((key) => {
+      let conditionValue = queryWhere[key];
+      if (key === 'and') {
+
+      } else if (key === 'or') {
+
+      } else {
+        returnExpression += addExpressionToParam(params, key, conditionValue, 'AND');
+      }
+    });
+    return returnExpression;
+  }
+
+  return analyzeQueryWhere(params, queryWhere);
+  
+}
+
 
 
 /**
@@ -1372,7 +1504,7 @@ DynamoDB.prototype.range = function (model, id, start, end, callback) {
  * 
  * return an object with Expression, ExpressionAttributeNames, and ExpressionAttributeValues
  */
-DynamoDB.prototype.generateExpression = (key, conditionValue, operator) => { // TODO: need to take in params
+DynamoDB.prototype.addExpressionToParam = (key, conditionValue, operator) => { // TODO: need to take in params
   if (key === "and") {
     throw new Error("And operator not currently supported");
   }

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -552,7 +552,7 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
 
   let params = {};
   let keyConditionExpression = me.generateExpression(params, keyQuery);
-  console.log(keyConditionExpression);
+  console.log(params.Expression);
   console.log(params.ExpressionAttributeNames);
   console.log(params.ExpressionAttributeValues);
 
@@ -1373,7 +1373,7 @@ DynamoDB.prototype.range = function (model, id, start, end, callback) {
 DynamoDB.prototype.generateExpression = (params, queryWhere) => {
 
   /**
-   * @param {Object}  params          hold ExpressionAttributeNames and ExpressionAttributeValues
+   * @param {Object}  params          hold Expression, ExpressionAttributeNames and ExpressionAttributeValues
    * @param {String}  key             The key in the where clause, either a property of the model, or a logical operator (and/or)
    * @param {String}  conditionValue  The condition that the key operates on
    * @param {String}  operator        'AND' or 'OR'
@@ -1387,16 +1387,24 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
       throw new Error("Or operator not currently supported");
     }
 
-    let returnExpression = "";
+    params.Expression = '';
     params.ExpressionAttributeNames = params.ExpressionAttributeNames || {};
     params.ExpressionAttributeValues = params.ExpressionAttributeValues || {};
 
     let attributeShorthand = "#" + key;
 
-    let prepExpressionAndAttributeName = () => {
-      if (returnExpression !== "") {
-        returnExpression += " " + operator + " "; // TODO: operator
-      }
+    // let prepExpressionAndAttributeName = () => {
+    //   if (params.Expression !== "") {
+    //     params.Expression += " " + operator + " "; // TODO: operator
+    //   }
+
+    //   params.ExpressionAttributeNames[attributeShorthand] = key;
+    // }
+
+    let prepExpressionAttributeName = () => {
+      // if (params.Expression !== "") {
+      //   params.Expression += " " + operator + " "; // TODO: operator
+      // }
 
       params.ExpressionAttributeNames[attributeShorthand] = key;
     }
@@ -1431,39 +1439,39 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
       let operators = Object.keys(conditionValue);
       operators.forEach((keyValue) => {
         //var useIndex = isIndexed(key, keyValue, conditionValue[keyValue], index);
-        prepExpressionAndAttributeName();
+        prepExpressionAttributeName();
         switch (keyValue) {
           case 'inq':
-              returnExpression += "(#" + key + " IN (" + getExpressionValueToken(conditionValue.inq) + ")" + ")";
+              params.Expression += "(#" + key + " IN (" + getExpressionValueToken(conditionValue.inq) + ")" + ")";
             break;
           case 'gt':
-              returnExpression += "(#" + key + " > " + getExpressionValueToken(conditionValue.gt) + ")";
+              params.Expression += "(#" + key + " > " + getExpressionValueToken(conditionValue.gt) + ")";
             break;
           case 'gte':
-              returnExpression += "(#" + key + " >= " + getExpressionValueToken(conditionValue.gte) + ")";
+              params.Expression += "(#" + key + " >= " + getExpressionValueToken(conditionValue.gte) + ")";
             break;
           case 'lt':
-              returnExpression += "(#" + key + " < " + getExpressionValueToken(conditionValue.lt) + ")";
+              params.Expression += "(#" + key + " < " + getExpressionValueToken(conditionValue.lt) + ")";
             break;
           case 'lte':
-              returnExpression += "(#" + key + " <= " + getExpressionValueToken(conditionValue.lte) + ")";
+              params.Expression += "(#" + key + " <= " + getExpressionValueToken(conditionValue.lte) + ")";
             break;
           case 'between':
-              returnExpression += "(#" + key + " BETWEEN " + getExpressionValueToken(conditionValue.between[0]) + " AND " + getExpressionValueToken(conditionValue.between[1]) + ")";
+              params.Expression += "(#" + key + " BETWEEN " + getExpressionValueToken(conditionValue.between[0]) + " AND " + getExpressionValueToken(conditionValue.between[1]) + ")";
             break;
           case 'nin':
-              returnExpression += "NOT " + "(#" + key + " IN (" + getExpressionValueToken(conditionValue.nin) + "))"
+              params.Expression += "NOT " + "(#" + key + " IN (" + getExpressionValueToken(conditionValue.nin) + "))"
               break;
           case 'near':
               throw new Error('near is not supported');
           case 'neq':
-              returnExpression += "(#" + key + " <> " + getExpressionValueToken(conditionValue.neq) + ")";
+              params.Expression += "(#" + key + " <> " + getExpressionValueToken(conditionValue.neq) + ")";
               break;
           case 'like':
-              returnExpression += "(contains(#" + key + "," + getExpressionValueToken(conditionValue.like) + "))";
+              params.Expression += "(contains(#" + key + "," + getExpressionValueToken(conditionValue.like) + "))";
               break;
           case 'nlike':
-              returnExpression += "(NOT contains(#" + key + "," + getExpressionValueToken(conditionValue.nlike) + "))";
+              params.Expression += "(NOT contains(#" + key + "," + getExpressionValueToken(conditionValue.nlike) + "))";
               break;
           case 'or':
           case 'and':
@@ -1472,13 +1480,15 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
       });
     } else {
       //Simple case -- do equivalency in query/scan notation.
-      prepExpressionAndAttributeName();
-      returnExpression += "#" + key + " = " + getExpressionValueToken(conditionValue);
+      prepExpressionAttributeName();
+      params.Expression += "(#" + key + " = " + getExpressionValueToken(conditionValue) + ')';
     }
+
+    // return returnExpression;
   }
 
   let analyzeQueryWhere = (params, queryWhere) => {
-    let returnExpression = "";
+    params.Expression = params.Expression || '';
     let properties = Object.keys(queryWhere);
     properties.forEach((key) => {
       let conditionValue = queryWhere[key];
@@ -1487,14 +1497,23 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
       } else if (key === 'or') {
 
       } else {
-        returnExpression += addExpressionToParam(params, key, conditionValue, 'AND');
+        let expression = params.Expression;
+        if (params.Expression !== '') {
+          addExpressionToParam(params, key, conditionValue, 'AND');
+          params.Expression = expression + ' and ' + params.Expression;
+        } else {
+          addExpressionToParam(params, key, conditionValue, 'AND');
+        }
+        //console.log(addExpressionToParam(params, key, conditionValue, 'AND'));
+        // console.log(expression);
       }
     });
-    return returnExpression;
   }
 
-  return analyzeQueryWhere(params, queryWhere);
-  
+  //let returnExpression = "";
+  analyzeQueryWhere(params, queryWhere);
+  // console.log(returnExpression);
+  // return returnExpression;
 }
 
 

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -516,9 +516,9 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
 
   // promote top level AND
   if (filter.where && filter.where.and) {
-    let newWhere = filter.where;
-    filter.where.and.forEach((obj) => {
-      let key = Object.keys(obj)[0];
+    var newWhere = filter.where;
+    filter.where.and.forEach(function (obj) {
+      var key = Object.keys(obj)[0];
       properties.push(key);
       newWhere[key] = obj[key];
     });
@@ -544,8 +544,8 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
   queryParams.TableName = this.tableName(model);
 
   if (properties) {
-    let obj = me.splitWhere(index, filter.where);
-    let params = {};
+    var obj = me.splitWhere(index, filter.where);
+    var params = {};
 
     if (obj.keyQuery) {
       queryParams.KeyConditionExpression = me.generateExpression(params, me.convertWhereObjectToAndArray(obj.keyQuery));
@@ -589,7 +589,7 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     if (fieldsToInclude.length > 0) {
       queryParams.ProjectionExpression = fieldsToInclude[0];
 
-      for (let i = 1; i < fieldsToInclude.length; i++) {
+      for (var i = 1; i < fieldsToInclude.length; i++) {
         queryParams.ProjectionExpression += ', ' + fieldsToInclude[i];
       }
     }
@@ -674,7 +674,7 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
  *                                  to be used to generate KeyConditionExpression and filterQuery is the whereObject to be used to 
  *                                  generate FilterExpression
  */
-DynamoDB.prototype.splitWhere = (index, whereObject) => {
+DynamoDB.prototype.splitWhere = function (index, whereObject) {
   /**
    * @param {String}  key               The key in the where clause, either a property of the model, or a logical operator (and/or)
    * @param {String}  operator          The operator the key is query on (e.g., 'lt', 'gt', 'between', 'eq', 'inq', etc.)
@@ -682,7 +682,7 @@ DynamoDB.prototype.splitWhere = (index, whereObject) => {
    * @param {Object}  index             Index object
    * return {Boolean}                   Return if the given key can be query with key (true), or has to be part of the FilterExpression
    */
-  let isIndexed = (key, operator, conditionValue, index) => {
+  var isIndexed = function (key, operator, conditionValue, index) {
     if (!index) {
       return false;
     } else if (index.rangeKey && index.rangeKey.key == key && ['lt', 'lte', 'gt', 'gte', 'between'].indexOf(operator) != -1) {
@@ -692,14 +692,14 @@ DynamoDB.prototype.splitWhere = (index, whereObject) => {
     }
   }
 
-  let analyzeWhereObject = (index, whereObject) => {
-    let obj = {};
-    let properties = Object.keys(whereObject);
-    properties.forEach((key) => {
-      let conditionValue = whereObject[key];
+  var analyzeWhereObject = function (index, whereObject) {
+    var obj = {};
+    var properties = Object.keys(whereObject);
+    properties.forEach(function (key) {
+      var conditionValue = whereObject[key];
       if (key === 'and') {
-        conditionValue.forEach((whereClause) => {
-          let returnObj = analyzeWhereObject(index, whereClause);
+        conditionValue.forEach(function (whereClause) {
+          var returnObj = analyzeWhereObject(index, whereClause);
           if (returnObj.keyQuery) {
             // we have keyQuery, need to save this for return
             obj.keyQuery = obj.keyQuery || {};
@@ -714,8 +714,8 @@ DynamoDB.prototype.splitWhere = (index, whereObject) => {
           }
         }); 
       } else if (key === 'or') {
-        conditionValue.forEach((whereClause) => {
-          let returnObj = analyzeWhereObject(index, whereClause);
+        conditionValue.forEach(function (whereClause) {
+          var returnObj = analyzeWhereObject(index, whereClause);
           if (returnObj.keyQuery) {
             // we have keyQuery, need to save this for return
             obj.keyQuery = obj.keyQuery || {};
@@ -732,7 +732,7 @@ DynamoDB.prototype.splitWhere = (index, whereObject) => {
 
         if (obj.keyQuery && obj.filterQuery && obj.keyQuery.or && obj.filterQuery.or) {
           // something is under filterQuery of OR, we need to move the keyQuery of OR in here too
-          obj.keyQuery.or.forEach((o) => { // concat doesn't work for some reason
+          obj.keyQuery.or.forEach(function (o) { // concat doesn't work for some reason
             obj.filterQuery.or.push(o);
           })
           obj.keyQuery.or.splice(0, obj.keyQuery.or.length);
@@ -740,8 +740,8 @@ DynamoDB.prototype.splitWhere = (index, whereObject) => {
         }
       } else {
         if (Object.prototype.toString.call(conditionValue) == '[object Object]') {
-          let operators = Object.keys(conditionValue);
-          operators.forEach((operator) => {
+          var operators = Object.keys(conditionValue);
+          operators.forEach(function (operator) {
             if (isIndexed(key, operator, conditionValue[operator], index)) {
               obj.keyQuery = obj.keyQuery || {};
               if (!obj.keyQuery[key]) {
@@ -775,11 +775,11 @@ DynamoDB.prototype.splitWhere = (index, whereObject) => {
   return analyzeWhereObject(index, whereObject);
 }
 
-DynamoDB.prototype.convertWhereObjectToAndArray = (whereObj) => {
-  let queryAnd = [];
-  let keys = Object.keys(whereObj);
-  keys.forEach((key) => {
-    let temp = {};
+DynamoDB.prototype.convertWhereObjectToAndArray = function (whereObj) {
+  var queryAnd = [];
+  var keys = Object.keys(whereObj);
+  keys.forEach(function (key) {
+    var temp = {};
     temp[key] = whereObj[key];
     queryAnd.push(temp);
   });
@@ -1362,7 +1362,7 @@ DynamoDB.prototype.range = function (model, id, start, end, callback) {
  * @params {Object}   queryWhere      the AND array converted from queryWhere object, either keyQuery or filterQuery
  * return  {String}                   return the Expression string, either KeyConditionExpression or FilterExpression (determined by caller)
  */
-DynamoDB.prototype.generateExpression = (params, queryWhereAnd) => {
+DynamoDB.prototype.generateExpression = function (params, queryWhereAnd) {
 
   /**
    * @param {Object}  params          hold ExpressionAttributeNames and ExpressionAttributeValues
@@ -1370,7 +1370,7 @@ DynamoDB.prototype.generateExpression = (params, queryWhereAnd) => {
    * @param {String}  conditionValue  The condition that the key operates on
    * return {String}  returnExpression
    */
-  let addExpressionToParam = (params, key, conditionValue) => {
+  var addExpressionToParam = function (params, key, conditionValue) {
     if (key === "and") {
       throw new Error("And operator not currently supported");
     }
@@ -1379,17 +1379,17 @@ DynamoDB.prototype.generateExpression = (params, queryWhereAnd) => {
       throw new Error("Or operator not currently supported");
     }
 
-    let returnExpression = '';
+    var returnExpression = '';
     params.ExpressionAttributeNames = params.ExpressionAttributeNames || {};
     params.ExpressionAttributeValues = params.ExpressionAttributeValues || {};
 
-    let attributeShorthand = "#" + key;
+    var attributeShorthand = "#" + key;
 
-    let prepExpressionAttributeName = () => {
+    var prepExpressionAttributeName = function () {
       params.ExpressionAttributeNames[attributeShorthand] = key;
     }
 
-    let getExpressionValueToken = (value) => {
+    var getExpressionValueToken = function (value) {
       if (!util.isArray(value)) {
         var token = value ? ":" + value.toString().replace(/[^a-zA-Z0-9]/g, "") : ":" + value;
 
@@ -1415,8 +1415,8 @@ DynamoDB.prototype.generateExpression = (params, queryWhereAnd) => {
     }
 
     if (Object.prototype.toString.call(conditionValue) == "[object Object]") {
-      let operators = Object.keys(conditionValue);
-      operators.forEach((keyValue) => {
+      var operators = Object.keys(conditionValue);
+      operators.forEach(function (keyValue) {
         prepExpressionAttributeName();
         switch (keyValue) {
           case 'inq':
@@ -1471,12 +1471,12 @@ DynamoDB.prototype.generateExpression = (params, queryWhereAnd) => {
     return returnExpression;
   }
 
-  let analyzeAndOr = (params, conditionValue, operator) => {
-    let returnExpressions = [];
+  var analyzeAndOr = function (params, conditionValue, operator) {
+    var returnExpressions = [];
     //console.log(conditionValue);
-    conditionValue.forEach((obj) => {
-      let key = Object.keys(obj)[0];
-      let value = obj[key];
+    conditionValue.forEach(function (obj) {
+      var key = Object.keys(obj)[0];
+      var value = obj[key];
       if (key === 'and') {
         returnExpressions.push(analyzeAndOr(params, value, ' AND '));
       } else if (key === 'or') {

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -543,62 +543,32 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
 
   queryParams.TableName = this.tableName(model);
 
-  // let obj = analyzeWhereObject(index, whereObject);
-  // let returnObj = {};
-
-  // if (obj.keyQuery) {
-  //   returnObj.keyQuery = {};
-  //   returnObj.keyQuery.and = [];
-  //   let keys = Object.keys(obj.keyQuery);
-  //   keys.forEach((key) => {
-  //     let temp = {};
-  //     temp[key] = obj.keyQuery[key];
-  //     returnObj.keyQuery.and.push(temp);
-  //   });
-  // }
-
-  // if (obj.filterQuery) {
-  //   returnObj.filterQuery = {};
-  //   returnObj.filterQuery.and = [];
-  //   let keys = Object.keys(obj.filterQuery);
-  //   keys.forEach((key) => {
-  //     let temp = {};
-  //     temp[key] = obj.filterQuery[key];
-  //     returnObj.filterQuery.and.push(temp);
-  //   });
-  // }
-
-
   if (properties) {
     let obj = me.splitWhere(index, filter.where);
     let params = {};
 
     if (obj.keyQuery) {
       // convert whereObject to AND array
-      let keyQueryAnd = [];
-      let keys = Object.keys(obj.keyQuery);
-      keys.forEach((key) => {
-        let temp = {};
-        temp[key] = obj.keyQuery[key];
-        keyQueryAnd.push(temp);
-      });
-      queryParams.KeyConditionExpression = me.generateExpression(params, keyQueryAnd);
-      //console.log(queryParams.KeyConditionExpression);
+      // let keyQueryAnd = [];
+      // let keys = Object.keys(obj.keyQuery);
+      // keys.forEach((key) => {
+      //   let temp = {};
+      //   temp[key] = obj.keyQuery[key];
+      //   keyQueryAnd.push(temp);
+      // });
+      queryParams.KeyConditionExpression = me.generateExpression(params, me.convertWhereObjectToAndArray(obj.keyQuery));
     }
 
     if (obj.filterQuery) {
       // convert whereObject to AND array
-      let filterQueryAnd = [];
-      let keys = Object.keys(obj.filterQuery);
-      keys.forEach((key) => {
-        let temp = {};
-        temp[key] = obj.filterQuery[key];
-        filterQueryAnd.push(temp);
-      });
-      // console.log(obj.filterQuery);
-      // console.log(filterQueryAnd);
-      queryParams.FilterExpression = me.generateExpression(params, filterQueryAnd);
-      //console.log(queryParams.FilterExpression);
+      // let filterQueryAnd = [];
+      // let keys = Object.keys(obj.filterQuery);
+      // keys.forEach((key) => {
+      //   let temp = {};
+      //   temp[key] = obj.filterQuery[key];
+      //   filterQueryAnd.push(temp);
+      // });
+      queryParams.FilterExpression = me.generateExpression(params, me.convertWhereObjectToAndArray(obj.filterQuery));
     }
 
     if (obj.keyQuery || obj.filterQuery) {
@@ -818,33 +788,18 @@ DynamoDB.prototype.splitWhere = (index, whereObject) => {
     return obj;
   }
 
-  // let obj = analyzeWhereObject(index, whereObject);
-  // let returnObj = {};
-
-  // if (obj.keyQuery) {
-  //   returnObj.keyQuery = {};
-  //   returnObj.keyQuery.and = [];
-  //   let keys = Object.keys(obj.keyQuery);
-  //   keys.forEach((key) => {
-  //     let temp = {};
-  //     temp[key] = obj.keyQuery[key];
-  //     returnObj.keyQuery.and.push(temp);
-  //   });
-  // }
-
-  // if (obj.filterQuery) {
-  //   returnObj.filterQuery = {};
-  //   returnObj.filterQuery.and = [];
-  //   let keys = Object.keys(obj.filterQuery);
-  //   keys.forEach((key) => {
-  //     let temp = {};
-  //     temp[key] = obj.filterQuery[key];
-  //     returnObj.filterQuery.and.push(temp);
-  //   });
-  // }
-
   return analyzeWhereObject(index, whereObject);
-  //return returnObj;
+}
+
+DynamoDB.prototype.convertWhereObjectToAndArray = (whereObj) => {
+  let queryAnd = [];
+  let keys = Object.keys(whereObj);
+  keys.forEach((key) => {
+    let temp = {};
+    temp[key] = whereObj[key];
+    queryAnd.push(temp);
+  });
+  return queryAnd;
 }
 
 DynamoDB.prototype.runAll = function (model, where, cb) {
@@ -1420,10 +1375,10 @@ DynamoDB.prototype.range = function (model, id, start, end, callback) {
  * return object with Expression (either KeyConditionExpression or FilterExpression)
  * 
  * @params {Object}   params          hold ExpressionAttributeNames and ExpressionAttributeValues
- * @params {Object}   queryWhere      the query whereObject from splitWhere, either keyQuery or filterQuery
+ * @params {Object}   queryWhere      the AND array converted from queryWhere object, either keyQuery or filterQuery
  * return  {String}                   return the Expression string, either KeyConditionExpression or FilterExpression (determined by caller)
  */
-DynamoDB.prototype.generateExpression = (params, queryWhere) => {
+DynamoDB.prototype.generateExpression = (params, queryWhereAnd) => {
 
   /**
    * @param {Object}  params          hold ExpressionAttributeNames and ExpressionAttributeValues
@@ -1534,6 +1489,7 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
 
   let analyzeAndOr = (params, conditionValue, operator) => {
     let returnExpressions = [];
+    //console.log(conditionValue);
     conditionValue.forEach((obj) => {
       let key = Object.keys(obj)[0];
       let value = obj[key];
@@ -1553,25 +1509,7 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
     }
   }
 
-  let analyzeQueryWhere = (params, queryWhere) => {
-    let returnExpressions = [];
-    let properties = Object.keys(queryWhere);
-    properties.forEach((key) => {
-      let conditionValue = queryWhere[key];
-      if (key === 'and') {
-        returnExpressions.push(analyzeAndOr(params, conditionValue, ' AND '));
-      } else if (key === 'or') {
-        returnExpressions.push(analyzeAndOr(params, conditionValue, ' OR '));
-      } else {
-        returnExpressions.push(addExpressionToParam(params, key, conditionValue));
-      }
-    });
-    
-    return returnExpressions.join(' AND ');
-  }
-
-  // return analyzeQueryWhere(params, queryWhere);
-  return analyzeAndOr(params, queryWhere, ' AND ');
+  return analyzeAndOr(params, queryWhereAnd, ' AND ');
 }
 
 function parameterizePath(path) {

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -768,10 +768,73 @@ DynamoDB.prototype.splitWhere = (index, whereObject) => {
       }
     });
 
+    // let returnObj = {};
+    // returnObj.keyQuery = {};
+    // returnObj.filterQuery = {};
+    // returnObj.keyQuery.and = [];
+    // returnObj.filterQuery.and = [];
+
+    // // console.log(obj.keyQuery);
+
+    // // let keys = Object.keys(obj.keyQuery);
+    // // keys.forEach((key) => {
+    // //   let temp = {};
+    // //   temp[key] = obj.keyQuery[key];
+    // //   returnObj.keyQuery.and.push(temp);
+    // // });
+
+    // // keys = Object.keys(obj.filterQuery);
+    // // keys.forEach((key) => {
+    // //   let temp = {};
+    // //   temp[key] = obj.filterQuery[key];
+    // //   returnObj.filterQuery.and.push(temp);
+    // // });
+
+    // // console.log(returnObj.keyQuery);
+    // // console.log(returnObj.filterQuery);
+
     return obj;
   }
 
-  return analyzeWhereObject(index, whereObject);
+  let obj = analyzeWhereObject(index, whereObject);
+  // console.log(obj.keyQuery);
+  let returnObj = {};
+  // returnObj.keyQuery = {};
+  // returnObj.filterQuery = {};
+  // returnObj.keyQuery.and = [];
+  // returnObj.filterQuery.and = [];
+
+  // console.log(obj.keyQuery);
+
+  if (obj.keyQuery) {
+    returnObj.keyQuery = {};
+    returnObj.keyQuery.and = [];
+    let keys = Object.keys(obj.keyQuery);
+    keys.forEach((key) => {
+      let temp = {};
+      temp[key] = obj.keyQuery[key];
+      returnObj.keyQuery.and.push(temp);
+    });
+  }
+
+  if (obj.filterQuery) {
+    returnObj.filterQuery = {};
+    returnObj.filterQuery.and = [];
+    let keys = Object.keys(obj.filterQuery);
+    keys.forEach((key) => {
+      let temp = {};
+      temp[key] = obj.filterQuery[key];
+      returnObj.filterQuery.and.push(temp);
+    });
+  }
+
+  // console.log(obj.keyQuery);
+  // console.log(returnObj.keyQuery.and);
+  // console.log(obj.filterQuery);
+  // console.log(returnObj.filterQuery.and);
+
+  //return obj;
+  return returnObj;
 }
 
 DynamoDB.prototype.runAll = function (model, where, cb) {
@@ -1496,7 +1559,9 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
     
     return returnExpressions.join(' AND ');
   }
-  return analyzeQueryWhere(params, queryWhere);
+
+  // return analyzeQueryWhere(params, queryWhere);
+  return analyzeAndOr(params, queryWhere.and, ' AND ');
 }
 
 function parameterizePath(path) {

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -1738,3 +1738,5 @@ exports.initialize = function initializeDataSource(dataSource, cb) {
     dataSource.connector.connect(cb);
   }
 };
+
+exports.DynamoDB = DynamoDB;

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -544,17 +544,28 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
   let obj = me.splitWhere(index, filter.where);
   let keyQuery = obj.keyQuery;
   let filterQuery = obj.filterQuery;
-  console.log(keyQuery);
-  console.log(filterQuery);
+  // console.log(keyQuery);
+  // console.log(filterQuery);
 
   // get both KeyConditionExpression and FilterExpression
   // also need ExpressionAttributeNames and ExpressionAttributeValues
 
   let params = {};
   let keyConditionExpression = me.generateExpression(params, keyQuery);
-  console.log(params.Expression);
-  console.log(params.ExpressionAttributeNames);
-  console.log(params.ExpressionAttributeValues);
+  //let keyConditionExpression = params.Expression;
+  me.generateExpression(params, filterQuery);
+  //et filterExpression = params.Expression;
+  let expressionAttributeNames = params.ExpressionAttributeNames;
+  let expressionAttributeValues = params.ExpressionAttributeValues;
+
+  // console.log('KeyConditionExpression');
+  console.log(keyConditionExpression);
+  // console.log('FilterExpression');
+  // //console.log(filterExpression);
+  // console.log('ExpressionAttributeNames');
+  // console.log(expressionAttributeNames);
+  // console.log('ExpressionAttributeValues');
+  // console.log(expressionAttributeValues);
 
 
   queryParams.TableName = this.tableName(model);
@@ -1373,12 +1384,12 @@ DynamoDB.prototype.range = function (model, id, start, end, callback) {
 DynamoDB.prototype.generateExpression = (params, queryWhere) => {
 
   /**
-   * @param {Object}  params          hold Expression, ExpressionAttributeNames and ExpressionAttributeValues
+   * @param {Object}  params          hold ExpressionAttributeNames and ExpressionAttributeValues
    * @param {String}  key             The key in the where clause, either a property of the model, or a logical operator (and/or)
    * @param {String}  conditionValue  The condition that the key operates on
-   * @param {String}  operator        'AND' or 'OR'
+   * return {String}  returnExpression
    */
-  let addExpressionToParam = (params, key, conditionValue, operator) => { // TODO: need to take in params
+  let addExpressionToParam = (params, key, conditionValue) => { // TODO: need to take in params
     if (key === "and") {
       throw new Error("And operator not currently supported");
     }
@@ -1387,7 +1398,7 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
       throw new Error("Or operator not currently supported");
     }
 
-    params.Expression = ''; // reset Expression to ''; caller will handle concatenation
+    let returnExpression = '';
     params.ExpressionAttributeNames = params.ExpressionAttributeNames || {};
     params.ExpressionAttributeValues = params.ExpressionAttributeValues || {};
 
@@ -1429,36 +1440,36 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
         prepExpressionAttributeName();
         switch (keyValue) {
           case 'inq':
-              params.Expression += "(#" + key + " IN (" + getExpressionValueToken(conditionValue.inq) + ")" + ")";
+              returnExpression += "(#" + key + " IN (" + getExpressionValueToken(conditionValue.inq) + ")" + ")";
             break;
           case 'gt':
-              params.Expression += "(#" + key + " > " + getExpressionValueToken(conditionValue.gt) + ")";
+              returnExpression += "(#" + key + " > " + getExpressionValueToken(conditionValue.gt) + ")";
             break;
           case 'gte':
-              params.Expression += "(#" + key + " >= " + getExpressionValueToken(conditionValue.gte) + ")";
+              returnExpression += "(#" + key + " >= " + getExpressionValueToken(conditionValue.gte) + ")";
             break;
           case 'lt':
-              params.Expression += "(#" + key + " < " + getExpressionValueToken(conditionValue.lt) + ")";
+              returnExpression += "(#" + key + " < " + getExpressionValueToken(conditionValue.lt) + ")";
             break;
           case 'lte':
-              params.Expression += "(#" + key + " <= " + getExpressionValueToken(conditionValue.lte) + ")";
+              returnExpression += "(#" + key + " <= " + getExpressionValueToken(conditionValue.lte) + ")";
             break;
           case 'between':
-              params.Expression += "(#" + key + " BETWEEN " + getExpressionValueToken(conditionValue.between[0]) + " AND " + getExpressionValueToken(conditionValue.between[1]) + ")";
+              returnExpression += "(#" + key + " BETWEEN " + getExpressionValueToken(conditionValue.between[0]) + " AND " + getExpressionValueToken(conditionValue.between[1]) + ")";
             break;
           case 'nin':
-              params.Expression += "NOT " + "(#" + key + " IN (" + getExpressionValueToken(conditionValue.nin) + "))"
+              returnExpression += "NOT " + "(#" + key + " IN (" + getExpressionValueToken(conditionValue.nin) + "))"
               break;
           case 'near':
               throw new Error('near is not supported');
           case 'neq':
-              params.Expression += "(#" + key + " <> " + getExpressionValueToken(conditionValue.neq) + ")";
+              returnExpression += "(#" + key + " <> " + getExpressionValueToken(conditionValue.neq) + ")";
               break;
           case 'like':
-              params.Expression += "(contains(#" + key + "," + getExpressionValueToken(conditionValue.like) + "))";
+              returnExpression += "(contains(#" + key + "," + getExpressionValueToken(conditionValue.like) + "))";
               break;
           case 'nlike':
-              params.Expression += "(NOT contains(#" + key + "," + getExpressionValueToken(conditionValue.nlike) + "))";
+              returnExpression += "(NOT contains(#" + key + "," + getExpressionValueToken(conditionValue.nlike) + "))";
               break;
           case 'or':
           case 'and':
@@ -1468,31 +1479,49 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
     } else {
       //Simple case -- do equivalency in query/scan notation.
       prepExpressionAttributeName();
-      params.Expression += "(#" + key + " = " + getExpressionValueToken(conditionValue) + ')';
+      returnExpression += "(#" + key + " = " + getExpressionValueToken(conditionValue) + ')';
     }
+
+    return returnExpression;
   }
 
   let analyzeQueryWhere = (params, queryWhere) => {
-    params.Expression = params.Expression || '';
+    let returnExpression = '';
     let properties = Object.keys(queryWhere);
     properties.forEach((key) => {
       let conditionValue = queryWhere[key];
       if (key === 'and') {
-
+        // conditionValue.forEach((whereClause) => {
+        //   let expression = params.Expression;
+        //   console.log(whereClause);
+        //   analyzeQueryWhere(params, whereClause);
+        //   if (expression !== '') {
+        //     params.Expression = expression + ' AND ' + params.Expression;
+        //   }
+        // });
       } else if (key === 'or') {
-
+        // conditionValue.forEach((whereClause) => {
+        //   let expression = params.Expression;
+        //   console.log(whereClause);
+        //   analyzeQueryWhere(params, whereClause);
+        //   if (expression !== '') {
+        //     params.Expression = expression + ' OR ' + params.Expression;
+        //   }
+        // });
       } else {
-        let expression = params.Expression;
-        addExpressionToParam(params, key, conditionValue, 'AND');
-        if (expression !== '') {
+        if (returnExpression !== '') {
           // concadenate with ' AND '
-          params.Expression = expression + ' AND ' + params.Expression;
+          returnExpression = returnExpression + ' AND ' + addExpressionToParam(params, key, conditionValue);
+        } else {
+          returnExpression = addExpressionToParam(params, key, conditionValue);
         }
       }
     });
+
+    return returnExpression;
   }
 
-  analyzeQueryWhere(params, queryWhere);
+  return analyzeQueryWhere(params, queryWhere);
 }
 
 

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -1387,25 +1387,13 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
       throw new Error("Or operator not currently supported");
     }
 
-    params.Expression = '';
+    params.Expression = ''; // reset Expression to ''; caller will handle concatenation
     params.ExpressionAttributeNames = params.ExpressionAttributeNames || {};
     params.ExpressionAttributeValues = params.ExpressionAttributeValues || {};
 
     let attributeShorthand = "#" + key;
 
-    // let prepExpressionAndAttributeName = () => {
-    //   if (params.Expression !== "") {
-    //     params.Expression += " " + operator + " "; // TODO: operator
-    //   }
-
-    //   params.ExpressionAttributeNames[attributeShorthand] = key;
-    // }
-
     let prepExpressionAttributeName = () => {
-      // if (params.Expression !== "") {
-      //   params.Expression += " " + operator + " "; // TODO: operator
-      // }
-
       params.ExpressionAttributeNames[attributeShorthand] = key;
     }
 
@@ -1438,7 +1426,6 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
     if (Object.prototype.toString.call(conditionValue) == "[object Object]") {
       let operators = Object.keys(conditionValue);
       operators.forEach((keyValue) => {
-        //var useIndex = isIndexed(key, keyValue, conditionValue[keyValue], index);
         prepExpressionAttributeName();
         switch (keyValue) {
           case 'inq':
@@ -1483,8 +1470,6 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
       prepExpressionAttributeName();
       params.Expression += "(#" + key + " = " + getExpressionValueToken(conditionValue) + ')';
     }
-
-    // return returnExpression;
   }
 
   let analyzeQueryWhere = (params, queryWhere) => {
@@ -1498,22 +1483,16 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
 
       } else {
         let expression = params.Expression;
-        if (params.Expression !== '') {
-          addExpressionToParam(params, key, conditionValue, 'AND');
-          params.Expression = expression + ' and ' + params.Expression;
-        } else {
-          addExpressionToParam(params, key, conditionValue, 'AND');
+        addExpressionToParam(params, key, conditionValue, 'AND');
+        if (expression !== '') {
+          // concadenate with ' AND '
+          params.Expression = expression + ' AND ' + params.Expression;
         }
-        //console.log(addExpressionToParam(params, key, conditionValue, 'AND'));
-        // console.log(expression);
       }
     });
   }
 
-  //let returnExpression = "";
   analyzeQueryWhere(params, queryWhere);
-  // console.log(returnExpression);
-  // return returnExpression;
 }
 
 

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -553,19 +553,18 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
   let params = {};
   let keyConditionExpression = me.generateExpression(params, keyQuery);
   //let keyConditionExpression = params.Expression;
-  me.generateExpression(params, filterQuery);
-  //et filterExpression = params.Expression;
+  let filterExpression = me.generateExpression(params, filterQuery);
   let expressionAttributeNames = params.ExpressionAttributeNames;
   let expressionAttributeValues = params.ExpressionAttributeValues;
 
-  // console.log('KeyConditionExpression');
+  console.log('KeyConditionExpression');
   console.log(keyConditionExpression);
-  // console.log('FilterExpression');
-  // //console.log(filterExpression);
-  // console.log('ExpressionAttributeNames');
-  // console.log(expressionAttributeNames);
-  // console.log('ExpressionAttributeValues');
-  // console.log(expressionAttributeValues);
+  console.log('FilterExpression');
+  console.log(filterExpression);
+  console.log('ExpressionAttributeNames');
+  console.log(expressionAttributeNames);
+  console.log('ExpressionAttributeValues');
+  console.log(expressionAttributeValues);
 
 
   queryParams.TableName = this.tableName(model);
@@ -1491,6 +1490,13 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
     properties.forEach((key) => {
       let conditionValue = queryWhere[key];
       if (key === 'and') {
+        conditionValue.forEach((whereClause) => {
+          if (returnExpression !== '') {
+            returnExpression = returnExpression + ' AND ' + analyzeQueryWhere(params, whereClause);
+          } else {
+            returnExpression = analyzeQueryWhere(params, whereClause);
+          }
+        });
         // conditionValue.forEach((whereClause) => {
         //   let expression = params.Expression;
         //   console.log(whereClause);
@@ -1500,6 +1506,15 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
         //   }
         // });
       } else if (key === 'or') {
+        conditionValue.forEach((whereClause) => {
+          if (returnExpression !== '') {
+            returnExpression = returnExpression + ' OR ' + analyzeQueryWhere(params, whereClause);
+          } else {
+            returnExpression = analyzeQueryWhere(params, whereClause);
+          }
+        });
+
+
         // conditionValue.forEach((whereClause) => {
         //   let expression = params.Expression;
         //   console.log(whereClause);

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -1464,21 +1464,17 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
     properties.forEach((key) => {
       let conditionValue = queryWhere[key];
       if (key === 'and') {
+        let returnExpressions = [];
         conditionValue.forEach((whereClause) => {
-          if (returnExpression !== '') {
-            returnExpression = returnExpression + ' AND ' + analyzeQueryWhere(params, whereClause);
-          } else {
-            returnExpression = analyzeQueryWhere(params, whereClause);
-          }
+          returnExpressions.push(analyzeQueryWhere(params, whereClause));
         });
+        returnExpression += returnExpressions.join(' AND ');
       } else if (key === 'or') {
+        let returnExpressions = [];
         conditionValue.forEach((whereClause) => {
-          if (returnExpression !== '') {
-            returnExpression = returnExpression + ' OR ' + analyzeQueryWhere(params, whereClause);
-          } else {
-            returnExpression = analyzeQueryWhere(params, whereClause);
-          }
+          returnExpressions.push(analyzeQueryWhere(params, whereClause));
         });
+        returnExpression += returnExpressions.join(' OR ');
       } else {
         if (returnExpression !== '') {
           // concadenate with ' AND '

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -531,7 +531,6 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     index = me.findIndex(properties, order && order[0], model);
   }
 
-
   //We have to use scan if the where clause is not indexed.
   if (!index) {
     findOperation = "scan";
@@ -613,7 +612,6 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     me.client[findOperation](params, function (err, data) {
       if (err) {
         debug.enabled && debug(err,params);
-        console.log(err);
         cb(err);
         return;
       }
@@ -731,7 +729,7 @@ DynamoDB.prototype.splitWhere = (index, whereObject) => {
 
         if (obj.keyQuery && obj.filterQuery && obj.keyQuery.or && obj.filterQuery.or) {
           // something is under filterQuery of OR, we need to move the keyQuery of OR in here too
-          obj.keyQuery.or.forEach((o) => { // concat doesn't work for some reason'
+          obj.keyQuery.or.forEach((o) => { // concat doesn't work for some reason
             obj.filterQuery.or.push(o);
           })
           obj.keyQuery.or.splice(0, obj.keyQuery.or.length);
@@ -1324,7 +1322,6 @@ DynamoDB.prototype.convertFilter = function convertFilter(model, filter) {
 
 // TODO: wrap this functionality in with the main .all implementation
 DynamoDB.prototype.range = function (model, id, start, end, callback) {
-  console.log("range function called");
   var properties = this.getPrimaryKeyProperties(model);
   var hash = properties[0], range = properties[1];
   if(!hash.isHash) hash = properties[1], range = properties[0];

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -541,45 +541,58 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     cb = filter;
   }
 
-  let obj = me.splitWhere(index, filter.where);
-  let keyQuery = obj.keyQuery;
-  let filterQuery = obj.filterQuery;
-  // console.log(keyQuery);
-  // console.log(filterQuery);
+  // let obj = me.splitWhere(index, filter.where);
+  // let keyQuery = obj.keyQuery;
+  // let filterQuery = obj.filterQuery;
+  // // console.log(keyQuery);
+  // // console.log(filterQuery);
 
-  // get both KeyConditionExpression and FilterExpression
-  // also need ExpressionAttributeNames and ExpressionAttributeValues
+  // // get both KeyConditionExpression and FilterExpression
+  // // also need ExpressionAttributeNames and ExpressionAttributeValues
 
-  let params = {};
-  let keyConditionExpression = me.generateExpression(params, keyQuery);
-  //let keyConditionExpression = params.Expression;
-  let filterExpression = me.generateExpression(params, filterQuery);
-  let expressionAttributeNames = params.ExpressionAttributeNames;
-  let expressionAttributeValues = params.ExpressionAttributeValues;
+  // let params = {};
+  // let keyConditionExpression = me.generateExpression(params, keyQuery);
+  // //let keyConditionExpression = params.Expression;
+  // let filterExpression = me.generateExpression(params, filterQuery);
+  // let expressionAttributeNames = params.ExpressionAttributeNames;
+  // let expressionAttributeValues = params.ExpressionAttributeValues;
 
-  console.log('KeyConditionExpression');
-  console.log(keyConditionExpression);
-  console.log('FilterExpression');
-  console.log(filterExpression);
-  console.log('ExpressionAttributeNames');
-  console.log(expressionAttributeNames);
-  console.log('ExpressionAttributeValues');
-  console.log(expressionAttributeValues);
+  // console.log('KeyConditionExpression');
+  // console.log(keyConditionExpression);
+  // console.log('FilterExpression');
+  // console.log(filterExpression);
+  // console.log('ExpressionAttributeNames');
+  // console.log(expressionAttributeNames);
+  // console.log('ExpressionAttributeValues');
+  // console.log(expressionAttributeValues);
 
 
   queryParams.TableName = this.tableName(model);
 
   if (properties) {
-    //console.log('before: ' + queryParams[1]);
-    me.addWhereObjectToConditions(queryParams, index, filter.where);
-    //console.log('after: ' + queryParams[1]);
-    //console.log(queryParams);
-    me.splitWhere(index, filter.where);
-    
-    if (!queryParams.KeyConditions) {
-      findOperation = "scan";
+    let obj = me.splitWhere(index, filter.where);
+    let params = {};
+    queryParams.KeyConditionExpression = me.generateExpression(params, obj.keyQuery);
+    queryParams.FilterExpression = me.generateExpression(params, obj.filterQuery);
+    queryParams.ExpressionAttributeNames = params.ExpressionAttributeNames;
+    queryParams.ExpressionAttributeValues = params.ExpressionAttributeValues;
+
+    if (queryParams.KeyConditionExpression === '') {
+      findOperation = 'scan';
     }
   }
+
+  // if (properties) {
+  //   //console.log('before: ' + queryParams[1]);
+  //   me.addWhereObjectToConditions(queryParams, index, filter.where);
+  //   //console.log('after: ' + queryParams[1]);
+  //   //console.log(queryParams);
+  //   me.splitWhere(index, filter.where);
+    
+  //   if (!queryParams.KeyConditions) {
+  //     findOperation = "scan";
+  //   }
+  // }
 
   //console.log(queryParams);
 

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -718,9 +718,37 @@ DynamoDB.prototype.splitWhere = (index, whereObject, operator) => {
     properties.forEach((key) => {
       let conditionValue = whereObject[key];
       if (key === 'and') {
-
+        conditionValue.forEach((whereClause) => {
+          let returnObj = analyzeWhereObject(index, whereClause, 'and');
+          if (returnObj.keyQuery) {
+            // we have keyQuery, need to save this for return
+            obj.keyQuery = obj.keyQuery || {};
+            obj.keyQuery.and = obj.keyQuery.and || [];
+            obj.keyQuery.and.push(returnObj.keyQuery);
+          }
+          if (returnObj.filterQuery) {
+            // we have filterQuery, need to save this for return
+            obj.filterQuery = obj.filterQuery || {};
+            obj.filterQuery.and = obj.filterQuery.and || [];
+            obj.filterQuery.and.push(returnObj.filterQuery);
+          }
+        }); 
       } else if (key === 'or') {
-
+        conditionValue.forEach((whereClause) => {
+          let returnObj = analyzeWhereObject(index, whereClause, 'or');
+          if (returnObj.keyQuery) {
+            // we have keyQuery, need to save this for return
+            obj.keyQuery = obj.keyQuery || {};
+            obj.keyQuery.or = obj.keyQuery.or || [];
+            obj.keyQuery.or.push(returnObj.keyQuery);
+          }
+          if (returnObj.filterQuery) {
+            // we have filterQuery, need to save this for return
+            obj.filterQuery = obj.filterQuery || {};
+            obj.filterQuery.or = obj.filterQuery.or || [];
+            obj.filterQuery.or.push(returnObj.filterQuery);
+          }
+        }); 
       } else {
         if (Object.prototype.toString.call(conditionValue) == '[object Object]') {
           let operators = Object.keys(conditionValue);
@@ -757,10 +785,13 @@ DynamoDB.prototype.splitWhere = (index, whereObject, operator) => {
 
     return obj;
   }
+  
 
   let obj = analyzeWhereObject(index, whereObject, operator);
   console.log(whereObject);
+  console.log("keyQuery");
   console.log(obj.keyQuery);
+  console.log("filterQuery");
   console.log(obj.filterQuery);
 
 

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -563,20 +563,23 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     }
   }
 
-  // console.log(queryParams);
+  console.log(queryParams);
 
-  // if (properties) {
-  //   //console.log('before: ' + queryParams[1]);
-  //   me.addWhereObjectToConditions(queryParams, index, filter.where);
-  //   //console.log('after: ' + queryParams[1]);
-  //   //console.log(queryParams);
-  //   //me.splitWhere(index, filter.where);
+  if (properties) {
+    //console.log('before: ' + queryParams[1]);
+    let oldParams = {};
+    me.addWhereObjectToConditions(oldParams, index, filter.where);
+    console.log(oldParams);
+    //me.addWhereObjectToConditions(queryParams, index, filter.where);
+    //console.log('after: ' + queryParams[1]);
+    //console.log(queryParams);
+    //me.splitWhere(index, filter.where);
     
-  //   if (!queryParams.KeyConditions) {
-  //     findOperation = "scan";
-  //     console.log('find operation is scan');
-  //   }
-  // }
+    // if (!queryParams.KeyConditions) {
+    //   findOperation = "scan";
+    //   console.log('find operation is scan');
+    // }
+  }
 
 
   // console.log(queryParams);
@@ -604,7 +607,6 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
       });
     }
 
-    //queryParams.AttributesToGet = fieldsToInclude;
     if (fieldsToInclude.length > 0) {
       queryParams.ProjectionExpression = fieldsToInclude[0];
 
@@ -634,6 +636,7 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     me.client[findOperation](params, function (err, data) {
       if (err) {
         debug.enabled && debug(err,params);
+        console.log(err);
         cb(err);
         return;
       }
@@ -652,6 +655,8 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
       cb();
     });
   }
+
+  //console.log(queryParams);
 
   runQuery(queryParams, function (err) {
     if (err) {
@@ -1455,7 +1460,15 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
         prepExpressionAttributeName();
         switch (keyValue) {
           case 'inq':
+            if (conditionValue[keyValue].length === 1) {
+              // we are using index (KeyConditionExpression) here
+              console.log('KeyConditionExpression');
+              returnExpression += "(#" + key + " = " + getExpressionValueToken(conditionValue.inq) + ')';
+            } else {
+              // FilterExpression here
+              console.log('FilterExpression');
               returnExpression += "(#" + key + " IN (" + getExpressionValueToken(conditionValue.inq) + ")" + ")";
+            }
             break;
           case 'gt':
               returnExpression += "(#" + key + " > " + getExpressionValueToken(conditionValue.gt) + ")";

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -543,14 +543,62 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
 
   queryParams.TableName = this.tableName(model);
 
+  // let obj = analyzeWhereObject(index, whereObject);
+  // let returnObj = {};
+
+  // if (obj.keyQuery) {
+  //   returnObj.keyQuery = {};
+  //   returnObj.keyQuery.and = [];
+  //   let keys = Object.keys(obj.keyQuery);
+  //   keys.forEach((key) => {
+  //     let temp = {};
+  //     temp[key] = obj.keyQuery[key];
+  //     returnObj.keyQuery.and.push(temp);
+  //   });
+  // }
+
+  // if (obj.filterQuery) {
+  //   returnObj.filterQuery = {};
+  //   returnObj.filterQuery.and = [];
+  //   let keys = Object.keys(obj.filterQuery);
+  //   keys.forEach((key) => {
+  //     let temp = {};
+  //     temp[key] = obj.filterQuery[key];
+  //     returnObj.filterQuery.and.push(temp);
+  //   });
+  // }
+
+
   if (properties) {
     let obj = me.splitWhere(index, filter.where);
     let params = {};
+
     if (obj.keyQuery) {
-      queryParams.KeyConditionExpression = me.generateExpression(params, obj.keyQuery);
+      // convert whereObject to AND array
+      let keyQueryAnd = [];
+      let keys = Object.keys(obj.keyQuery);
+      keys.forEach((key) => {
+        let temp = {};
+        temp[key] = obj.keyQuery[key];
+        keyQueryAnd.push(temp);
+      });
+      queryParams.KeyConditionExpression = me.generateExpression(params, keyQueryAnd);
+      //console.log(queryParams.KeyConditionExpression);
     }
+
     if (obj.filterQuery) {
-      queryParams.FilterExpression = me.generateExpression(params, obj.filterQuery);
+      // convert whereObject to AND array
+      let filterQueryAnd = [];
+      let keys = Object.keys(obj.filterQuery);
+      keys.forEach((key) => {
+        let temp = {};
+        temp[key] = obj.filterQuery[key];
+        filterQueryAnd.push(temp);
+      });
+      // console.log(obj.filterQuery);
+      // console.log(filterQueryAnd);
+      queryParams.FilterExpression = me.generateExpression(params, filterQueryAnd);
+      //console.log(queryParams.FilterExpression);
     }
 
     if (obj.keyQuery || obj.filterQuery) {
@@ -767,74 +815,36 @@ DynamoDB.prototype.splitWhere = (index, whereObject) => {
         }
       }
     });
-
-    // let returnObj = {};
-    // returnObj.keyQuery = {};
-    // returnObj.filterQuery = {};
-    // returnObj.keyQuery.and = [];
-    // returnObj.filterQuery.and = [];
-
-    // // console.log(obj.keyQuery);
-
-    // // let keys = Object.keys(obj.keyQuery);
-    // // keys.forEach((key) => {
-    // //   let temp = {};
-    // //   temp[key] = obj.keyQuery[key];
-    // //   returnObj.keyQuery.and.push(temp);
-    // // });
-
-    // // keys = Object.keys(obj.filterQuery);
-    // // keys.forEach((key) => {
-    // //   let temp = {};
-    // //   temp[key] = obj.filterQuery[key];
-    // //   returnObj.filterQuery.and.push(temp);
-    // // });
-
-    // // console.log(returnObj.keyQuery);
-    // // console.log(returnObj.filterQuery);
-
     return obj;
   }
 
-  let obj = analyzeWhereObject(index, whereObject);
-  // console.log(obj.keyQuery);
-  let returnObj = {};
-  // returnObj.keyQuery = {};
-  // returnObj.filterQuery = {};
-  // returnObj.keyQuery.and = [];
-  // returnObj.filterQuery.and = [];
+  // let obj = analyzeWhereObject(index, whereObject);
+  // let returnObj = {};
 
-  // console.log(obj.keyQuery);
+  // if (obj.keyQuery) {
+  //   returnObj.keyQuery = {};
+  //   returnObj.keyQuery.and = [];
+  //   let keys = Object.keys(obj.keyQuery);
+  //   keys.forEach((key) => {
+  //     let temp = {};
+  //     temp[key] = obj.keyQuery[key];
+  //     returnObj.keyQuery.and.push(temp);
+  //   });
+  // }
 
-  if (obj.keyQuery) {
-    returnObj.keyQuery = {};
-    returnObj.keyQuery.and = [];
-    let keys = Object.keys(obj.keyQuery);
-    keys.forEach((key) => {
-      let temp = {};
-      temp[key] = obj.keyQuery[key];
-      returnObj.keyQuery.and.push(temp);
-    });
-  }
+  // if (obj.filterQuery) {
+  //   returnObj.filterQuery = {};
+  //   returnObj.filterQuery.and = [];
+  //   let keys = Object.keys(obj.filterQuery);
+  //   keys.forEach((key) => {
+  //     let temp = {};
+  //     temp[key] = obj.filterQuery[key];
+  //     returnObj.filterQuery.and.push(temp);
+  //   });
+  // }
 
-  if (obj.filterQuery) {
-    returnObj.filterQuery = {};
-    returnObj.filterQuery.and = [];
-    let keys = Object.keys(obj.filterQuery);
-    keys.forEach((key) => {
-      let temp = {};
-      temp[key] = obj.filterQuery[key];
-      returnObj.filterQuery.and.push(temp);
-    });
-  }
-
-  // console.log(obj.keyQuery);
-  // console.log(returnObj.keyQuery.and);
-  // console.log(obj.filterQuery);
-  // console.log(returnObj.filterQuery.and);
-
-  //return obj;
-  return returnObj;
+  return analyzeWhereObject(index, whereObject);
+  //return returnObj;
 }
 
 DynamoDB.prototype.runAll = function (model, where, cb) {
@@ -1561,7 +1571,7 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
   }
 
   // return analyzeQueryWhere(params, queryWhere);
-  return analyzeAndOr(params, queryWhere.and, ' AND ');
+  return analyzeAndOr(params, queryWhere, ' AND ');
 }
 
 function parameterizePath(path) {

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -516,7 +516,7 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
 
   // promote top level AND
   if (filter.where && filter.where.and) {
-    let newWhere = {};
+    let newWhere = filter.where;
     filter.where.and.forEach((obj) => {
       let key = Object.keys(obj)[0];
       properties.push(key);
@@ -524,6 +524,7 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     });
 
     properties.splice(properties.indexOf('and'), 1);
+    delete newWhere.and;
     filter.where = newWhere;
   }
 

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -548,26 +548,10 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     let params = {};
 
     if (obj.keyQuery) {
-      // convert whereObject to AND array
-      // let keyQueryAnd = [];
-      // let keys = Object.keys(obj.keyQuery);
-      // keys.forEach((key) => {
-      //   let temp = {};
-      //   temp[key] = obj.keyQuery[key];
-      //   keyQueryAnd.push(temp);
-      // });
       queryParams.KeyConditionExpression = me.generateExpression(params, me.convertWhereObjectToAndArray(obj.keyQuery));
     }
 
     if (obj.filterQuery) {
-      // convert whereObject to AND array
-      // let filterQueryAnd = [];
-      // let keys = Object.keys(obj.filterQuery);
-      // keys.forEach((key) => {
-      //   let temp = {};
-      //   temp[key] = obj.filterQuery[key];
-      //   filterQueryAnd.push(temp);
-      // });
       queryParams.FilterExpression = me.generateExpression(params, me.convertWhereObjectToAndArray(obj.filterQuery));
     }
 

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -445,8 +445,6 @@ DynamoDB.prototype.scanIds = function scanIds(model, callback) {
 };
 
 /**
-
-
  * Find matching model instances by the filter
  *
  * @param {String} model The model name
@@ -516,7 +514,28 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     order = filter.order.split(' ');
   }
 
+  // if filter.where.AND key, move the array out
+  // let testVar = null;
+  // if (testVar && testVar.testField) {
+  //   console.log("exist");
+  // } else {
+  //   console.log("non exist");
+  // }
+  
+  if (filter.where && filter.where.and) {
+    filter.where.and.forEach((obj) => {
+      let key = Object.keys(obj)[0];
+      properties.push(key);
+      filter.where[key] = obj[key];
+    });
+
+    properties.splice(properties.indexOf('and'), 1);
+    delete filter.where.and;
+  }
+
   if (properties) {
+    console.log(properties);
+    console.log(filter.where);
     index = me.findIndex(properties, order && order[0], model);
   }
 

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -535,16 +535,8 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     filter.where = newWhere;
   }
 
-  console.log("properties");
-  console.log(properties);
-  console.log("where");
-  console.log(filter.where);
-
   if (properties) {
-    // console.log(properties);
-    // console.log(filter.where);
     index = me.findIndex(properties, order && order[0], model);
-    //console.log(index);
   }
 
 
@@ -556,6 +548,14 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
   if (!cb) {
     cb = filter;
   }
+
+  let obj = this.splitWhere(index, filter.where);
+  let keyQuery = obj.keyQuery;
+  let filterQuery = obj.filterQuery;
+  console.log(keyQuery);
+  console.log(filterQuery);
+
+
 
   queryParams.TableName = this.tableName(model);
 
@@ -672,30 +672,7 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
   });
 };
 
-
-  // // TODO: split where into index where and non-index where
-  // function isIndexed(key, operator, conditionValue, index) {
-  //   var useIndex = false;
-  //   // if key == index.rangeKey and operator in [ eq, lt, lte, gt, gte, between]
-  //   // OR if key == index.hashKey and (operator is eq OR operator is INQ with set length of 1)
-  //     // see if rangeKey and supported operator
-  //   if (!index) {
-  //     return false;
-  //   } else if (index.rangeKey && index.rangeKey.key === key &&
-  //     ['lt', 'lte', 'gt', 'gte', 'between'].indexOf(operator) != -1) {
-  //     useIndex = true;
-  //   } else if (index.hashKey.key === key || (index.rangeKey && index.rangeKey.key === key)) {
-  //     useIndex = (operator === 'eq') || (operator === 'inq' && conditionValue.length === 1);
-  //   }
-  //   return useIndex;
-  // }
-
-
-DynamoDB.prototype.splitWhere = (index, whereObject, operator) => {
-  let returnObject = {};
-  returnObject.keyQuery = {};
-  //console.log("returnObject.keyQuery is " + returnObject.keyQuery);
-  returnObject.filterQuery = {};
+DynamoDB.prototype.splitWhere = (index, whereObject) => {
 
   /**
    * @param {String}  key               The key in the where clause, either a property of the model, or a logical operator (and/or)
@@ -713,13 +690,8 @@ DynamoDB.prototype.splitWhere = (index, whereObject, operator) => {
     }
   }
 
-  // let getCondition = ()
-
   let analyzeWhereObject = (index, whereObject) => {
     let obj = {};
-    // obj.keyQuery = obj.keyQuery || {};
-    // obj.filterQuery = obj.filterQuery || {};
-
     let properties = Object.keys(whereObject);
     properties.forEach((key) => {
       let conditionValue = whereObject[key];
@@ -770,20 +742,18 @@ DynamoDB.prototype.splitWhere = (index, whereObject, operator) => {
           operators.forEach((operator) => {
             if (isIndexed(key, operator, conditionValue[operator], index)) {
               obj.keyQuery = obj.keyQuery || {};
-              if (!returnObject.keyQuery[key]) {
+              if (!obj.keyQuery[key]) {
                 obj.keyQuery[key] = { [operator]: conditionValue[operator] };
               } else {
                 obj.keyQuery[key][operator] = conditionValue[operator];
               }
             } else {
               obj.filterQuery = obj.filterQuery || {};
-              if (!returnObject.filterQuery[key]) {
+              if (!obj.filterQuery[key]) {
                 obj.filterQuery[key] = { [operator]: conditionValue[operator] };
               } else {
                 obj.filterQuery[key][operator] = conditionValue[operator];
               }
-
-              //returnObject.filterQuery.key.operator = conditionValue;
             }
           })
         } else {
@@ -800,110 +770,9 @@ DynamoDB.prototype.splitWhere = (index, whereObject, operator) => {
 
     return obj;
   }
-  console.log("index");
-  console.log(index);
 
-  let obj = analyzeWhereObject(index, whereObject, operator);
-  console.log(whereObject);
-  console.log("keyQuery");
-  console.log(obj.keyQuery);
-  console.log("filterQuery");
-  console.log(obj.filterQuery);
-
-
-  // let analyzeWhereObject = (index, whereObject, condition) => {
-  //   let properties = Object.keys(whereObject);
-  //   properties.forEach((key) => {
-  //     let conditionValue = whereObject[key];
-  //     if (key === 'and') {
-  //       let returnObj = {};
-  //       returnObj.keyQuery = {};
-  //       returnObj.filterQuery = {};
-  //       conditionValue.forEach((whereClause) => {
-  //         //console.log('and');
-  //         //let param;
-  //         let obj = analyzeWhereObject(index, whereClause, 'AND');
-  //         if (obj.keyQuery) {
-  //           // has keyQuery
-  //           returnObj.keyQuery.and.push(obj)
-  //         }
-  //       });
-  //     } else if (key === 'or') {
-  //       conditionValue.forEach((whereClause) => {
-  //         //console.log('or');
-  //         analyzeWhereObject(index, whereClause, 'OR');
-  //       });
-  //     } else {
-  //       // TODO
-  //       //console.log(key);
-  //       if (Object.prototype.toString.call(conditionValue) == '[object Object]') {
-  //         // TODO
-  //         let operators = Object.keys(conditionValue);
-  //         operators.forEach((operator) => {
-  //           if (isIndexed(key, operator, conditionValue[operator], index)) {
-  //             if (!condition) {
-  //               // single condition
-  //               returnObject.keyQuery[key] = { [operator]: conditionValue[operator] };
-  //             } else {
-
-  //             }
-
-
-
-
-  //             if (!returnObject.keyQuery[key]) {
-  //               returnObject.keyQuery[key] = { [operator]: conditionValue[operator] };
-  //             } else {
-  //               returnObject.keyQuery[key][operator] = conditionValue[operator];
-  //             }
-  //           } else {
-  //             if (!returnObject.filterQuery[key]) {
-  //               returnObject.filterQuery[key] = { [operator]: conditionValue[operator] };
-  //             } else {
-  //               returnObject.filterQuery[key][operator] = conditionValue[operator];
-  //             }
-
-  //             //returnObject.filterQuery.key.operator = conditionValue;
-  //           }
-  //         })
-  //       } else {
-  //         if (isIndexed(key, 'eq', conditionValue, index)) {
-  //           returnObject.keyQuery[key] = conditionValue;
-  //         } else {
-  //           returnObject.filterQuery[key] = conditionValue;
-  //         }
-  //       }
-  //     }
-  //   });
-  //   //});
-  // };
-
-  // analyzeWhereObject(index, whereObject, operator);
-  // console.log(whereObject);
-  // console.log(returnObject.keyQuery);
-  // console.log(returnObject.filterQuery);
+  return analyzeWhereObject(index, whereObject);
 }
-
-// DynamoDB.prototype.addWhereObjectToConditions = function (params, index, whereObject, operator) {
-//   var properties = Object.keys(whereObject),
-//     me = this;
-//   //For each property in the where condition, decide what to add to the query or scan operation.
-//   properties.forEach(function (conditionKey) {
-//     var whereValue = whereObject[conditionKey];
-//     if (conditionKey === "and") {
-//       whereValue.forEach(function (whereClause) {
-//         me.addWhereObjectToConditions(params, index, whereClause, 'AND');
-//       });
-//     } else if (conditionKey === "or") {
-//       whereValue.forEach(function (whereClause) {
-//         me.addWhereObjectToConditions(params, index, whereClause, 'OR');
-//       });
-//     } else {
-//       me.addConditionToParam(params, index, conditionKey, whereValue, operator || "AND");
-//     }
-
-//   });
-// };
 
 DynamoDB.prototype.runAll = function (model, where, cb) {
   //If no criteria is provided, refuse to perform the costly scan/delete operation.

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -532,7 +532,6 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     });
 
     properties.splice(properties.indexOf('and'), 1);
-    // delete filter.where.and;
     filter.where = newWhere;
   }
 
@@ -716,7 +715,7 @@ DynamoDB.prototype.splitWhere = (index, whereObject, operator) => {
 
   // let getCondition = ()
 
-  let analyzeWhereObject = (index, whereObject, condition) => {
+  let analyzeWhereObject = (index, whereObject) => {
     let obj = {};
     // obj.keyQuery = obj.keyQuery || {};
     // obj.filterQuery = obj.filterQuery || {};
@@ -726,7 +725,7 @@ DynamoDB.prototype.splitWhere = (index, whereObject, operator) => {
       let conditionValue = whereObject[key];
       if (key === 'and') {
         conditionValue.forEach((whereClause) => {
-          let returnObj = analyzeWhereObject(index, whereClause, 'and');
+          let returnObj = analyzeWhereObject(index, whereClause);
           if (returnObj.keyQuery) {
             // we have keyQuery, need to save this for return
             obj.keyQuery = obj.keyQuery || {};
@@ -742,7 +741,7 @@ DynamoDB.prototype.splitWhere = (index, whereObject, operator) => {
         }); 
       } else if (key === 'or') {
         conditionValue.forEach((whereClause) => {
-          let returnObj = analyzeWhereObject(index, whereClause, 'or');
+          let returnObj = analyzeWhereObject(index, whereClause);
           if (returnObj.keyQuery) {
             // we have keyQuery, need to save this for return
             obj.keyQuery = obj.keyQuery || {};
@@ -755,7 +754,16 @@ DynamoDB.prototype.splitWhere = (index, whereObject, operator) => {
             obj.filterQuery.or = obj.filterQuery.or || [];
             obj.filterQuery.or.push(returnObj.filterQuery);
           }
-        }); 
+        });
+
+        if (obj.keyQuery && obj.filterQuery && obj.keyQuery.or && obj.filterQuery.or) {
+          // something is under filterQuery of OR, we need to move the keyQuery of OR in here too
+          obj.keyQuery.or.forEach((o) => { // concat doesn't work for some reason'
+            obj.filterQuery.or.push(o);
+          })
+          obj.keyQuery.or.splice(0, obj.keyQuery.or.length);
+          obj.keyQuery.or = undefined;
+        }
       } else {
         if (Object.prototype.toString.call(conditionValue) == '[object Object]') {
           let operators = Object.keys(conditionValue);

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -707,55 +707,37 @@ DynamoDB.prototype.splitWhere = (index, whereObject, operator) => {
     }
   }
 
+  // let getCondition = ()
+
   let analyzeWhereObject = (index, whereObject, condition) => {
+    let obj = {};
+    // obj.keyQuery = obj.keyQuery || {};
+    // obj.filterQuery = obj.filterQuery || {};
+
     let properties = Object.keys(whereObject);
     properties.forEach((key) => {
       let conditionValue = whereObject[key];
-      // if (key === 'and') {
-      //   conditionValue.forEach((whereClause) => {
-      //     //console.log('and');
-      //     analyzeWhereObject(index, whereClause, 'AND');
-      //   });
-      // } else if (key === 'or') {
-      //   conditionValue.forEach((whereClause) => {
-      //     //console.log('or');
-      //     analyzeWhereObject(index, whereClause, 'OR');
-      //   });
-      // } else {
-        // TODO
-        //console.log(key);
+      if (key === 'and') {
+
+      } else if (key === 'or') {
+
+      } else {
         if (Object.prototype.toString.call(conditionValue) == '[object Object]') {
-          // TODO
           let operators = Object.keys(conditionValue);
           operators.forEach((operator) => {
             if (isIndexed(key, operator, conditionValue[operator], index)) {
-              // // if (!returnObject.keyQuery[key]) {
-              // //   console.log("key is null");
-              // //   returnObject.keyQuery[key] = {};
-              // //   console.log("returnObject.keyQuery[key] is " + returnObject.keyQuery.key);
-              // // }
-              // returnObject.keyQuery[key] = returnObject.keyQuery[key] || {};
-              // console.log("returnObject.keyQuery[key] is " + returnObject.keyQuery.key);
-
-              // console.log("key is " + key);
-              // console.log("operator is " + operator);
-              // console.log("condtionValue is " + conditionValue);
-              // console.log("conditionValue[operator] is " + conditionValue[operator]);
-              // //returnObject.keyQuery[key].operator = conditionValue;
-              // //returnObject.keyQuery.key[operator] = conditionValue;
-              // returnObject.keyQuery[key] = 
-              // //returnObject.keyQuery.key.operator = "hello";
-
+              obj.keyQuery = obj.keyQuery || {};
               if (!returnObject.keyQuery[key]) {
-                returnObject.keyQuery[key] = { [operator]: conditionValue[operator] };
+                obj.keyQuery[key] = { [operator]: conditionValue[operator] };
               } else {
-                returnObject.keyQuery[key][operator] = conditionValue[operator];
+                obj.keyQuery[key][operator] = conditionValue[operator];
               }
             } else {
+              obj.filterQuery = obj.filterQuery || {};
               if (!returnObject.filterQuery[key]) {
-                returnObject.filterQuery[key] = { [operator]: conditionValue[operator] };
+                obj.filterQuery[key] = { [operator]: conditionValue[operator] };
               } else {
-                returnObject.filterQuery[key][operator] = conditionValue[operator];
+                obj.filterQuery[key][operator] = conditionValue[operator];
               }
 
               //returnObject.filterQuery.key.operator = conditionValue;
@@ -763,20 +745,96 @@ DynamoDB.prototype.splitWhere = (index, whereObject, operator) => {
           })
         } else {
           if (isIndexed(key, 'eq', conditionValue, index)) {
-            returnObject.keyQuery[key] = conditionValue;
+            obj.keyQuery = obj.keyQuery || {};
+            obj.keyQuery[key] = conditionValue;
           } else {
-            returnObject.filterQuery[key] = conditionValue;
+            obj.filterQuery = obj.filterQuery || {};
+            obj.filterQuery[key] = conditionValue;
           }
         }
-    //   }
-    // });
+      }
     });
-  };
 
-  analyzeWhereObject(index, whereObject, operator);
+    return obj;
+  }
+
+  let obj = analyzeWhereObject(index, whereObject, operator);
   console.log(whereObject);
-  console.log(returnObject.keyQuery);
-  console.log(returnObject.filterQuery);
+  console.log(obj.keyQuery);
+  console.log(obj.filterQuery);
+
+
+  // let analyzeWhereObject = (index, whereObject, condition) => {
+  //   let properties = Object.keys(whereObject);
+  //   properties.forEach((key) => {
+  //     let conditionValue = whereObject[key];
+  //     if (key === 'and') {
+  //       let returnObj = {};
+  //       returnObj.keyQuery = {};
+  //       returnObj.filterQuery = {};
+  //       conditionValue.forEach((whereClause) => {
+  //         //console.log('and');
+  //         //let param;
+  //         let obj = analyzeWhereObject(index, whereClause, 'AND');
+  //         if (obj.keyQuery) {
+  //           // has keyQuery
+  //           returnObj.keyQuery.and.push(obj)
+  //         }
+  //       });
+  //     } else if (key === 'or') {
+  //       conditionValue.forEach((whereClause) => {
+  //         //console.log('or');
+  //         analyzeWhereObject(index, whereClause, 'OR');
+  //       });
+  //     } else {
+  //       // TODO
+  //       //console.log(key);
+  //       if (Object.prototype.toString.call(conditionValue) == '[object Object]') {
+  //         // TODO
+  //         let operators = Object.keys(conditionValue);
+  //         operators.forEach((operator) => {
+  //           if (isIndexed(key, operator, conditionValue[operator], index)) {
+  //             if (!condition) {
+  //               // single condition
+  //               returnObject.keyQuery[key] = { [operator]: conditionValue[operator] };
+  //             } else {
+
+  //             }
+
+
+
+
+  //             if (!returnObject.keyQuery[key]) {
+  //               returnObject.keyQuery[key] = { [operator]: conditionValue[operator] };
+  //             } else {
+  //               returnObject.keyQuery[key][operator] = conditionValue[operator];
+  //             }
+  //           } else {
+  //             if (!returnObject.filterQuery[key]) {
+  //               returnObject.filterQuery[key] = { [operator]: conditionValue[operator] };
+  //             } else {
+  //               returnObject.filterQuery[key][operator] = conditionValue[operator];
+  //             }
+
+  //             //returnObject.filterQuery.key.operator = conditionValue;
+  //           }
+  //         })
+  //       } else {
+  //         if (isIndexed(key, 'eq', conditionValue, index)) {
+  //           returnObject.keyQuery[key] = conditionValue;
+  //         } else {
+  //           returnObject.filterQuery[key] = conditionValue;
+  //         }
+  //       }
+  //     }
+  //   });
+  //   //});
+  // };
+
+  // analyzeWhereObject(index, whereObject, operator);
+  // console.log(whereObject);
+  // console.log(returnObject.keyQuery);
+  // console.log(returnObject.filterQuery);
 }
 
 // DynamoDB.prototype.addWhereObjectToConditions = function (params, index, whereObject, operator) {

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -548,20 +548,18 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     let params = {};
     if (obj.keyQuery) {
       queryParams.KeyConditionExpression = me.generateExpression(params, obj.keyQuery);
-    } else {
-      console.log('no keyQuery');
     }
     if (obj.filterQuery) {
       queryParams.FilterExpression = me.generateExpression(params, obj.filterQuery);
-    } else {
-      console.log('no filterQuery');
     }
-    queryParams.ExpressionAttributeNames = params.ExpressionAttributeNames;
-    queryParams.ExpressionAttributeValues = params.ExpressionAttributeValues;
+
+    if (obj.keyQuery || obj.filterQuery) {
+      queryParams.ExpressionAttributeNames = params.ExpressionAttributeNames;
+      queryParams.ExpressionAttributeValues = params.ExpressionAttributeValues;
+    }
 
     if (!queryParams.KeyConditionExpression || queryParams.KeyConditionExpression === '') {
       findOperation = 'scan';
-      console.log('findOperation is scan');
     }
   }
 
@@ -587,10 +585,8 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
 
   if (order && findOperation === "query") {
     if (order[1] === 'ASC') {
-      console.log("forward true");
       queryParams.ScanIndexForward = true;
     } else {
-      console.log('forward false');
       queryParams.ScanIndexForward = false;
     }
   }
@@ -627,7 +623,6 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
   }
 
   function runQuery(params, cb) {
-    console.log('runQuery');
     if (filter.limit) {
       var max = filter.skip ? filter.limit + filter.skip : filter.limit;
       if (items.length >= max) {
@@ -637,9 +632,7 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     }
     debug && debug(params);
     me.client[findOperation](params, function (err, data) {
-      console.log('me.client[findOperation] cb');
       if (err) {
-        console.log(err);
         debug.enabled && debug(err,params);
         cb(err);
         return;
@@ -659,8 +652,6 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
       cb();
     });
   }
-
-  console.log(queryParams);
 
   runQuery(queryParams, function (err) {
     if (err) {
@@ -692,8 +683,6 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
         cb(err, items);
       }
     });
-
-
   });
 };
 

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -538,7 +538,9 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     // console.log(properties);
     // console.log(filter.where);
     index = me.findIndex(properties, order && order[0], model);
+    //console.log(index);
   }
+
 
   //We have to use scan if the where clause is not indexed.
   if (!index) {
@@ -555,7 +557,8 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     //console.log('before: ' + queryParams[1]);
     me.addWhereObjectToConditions(queryParams, index, filter.where);
     //console.log('after: ' + queryParams[1]);
-    console.log(queryParams);
+    //console.log(queryParams);
+    me.splitWhere(index, filter.where);
     
     if (!queryParams.KeyConditions) {
       findOperation = "scan";
@@ -662,6 +665,103 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
 
   });
 };
+
+
+  // // TODO: split where into index where and non-index where
+  // function isIndexed(key, operator, conditionValue, index) {
+  //   var useIndex = false;
+  //   // if key == index.rangeKey and operator in [ eq, lt, lte, gt, gte, between]
+  //   // OR if key == index.hashKey and (operator is eq OR operator is INQ with set length of 1)
+  //     // see if rangeKey and supported operator
+  //   if (!index) {
+  //     return false;
+  //   } else if (index.rangeKey && index.rangeKey.key === key &&
+  //     ['lt', 'lte', 'gt', 'gte', 'between'].indexOf(operator) != -1) {
+  //     useIndex = true;
+  //   } else if (index.hashKey.key === key || (index.rangeKey && index.rangeKey.key === key)) {
+  //     useIndex = (operator === 'eq') || (operator === 'inq' && conditionValue.length === 1);
+  //   }
+  //   return useIndex;
+  // }
+
+
+DynamoDB.prototype.splitWhere = (index, whereObject, operator) => {
+  let returnObject = {};
+  returnObject.keyQuery = {};
+  returnObject.filterQuery = {};
+
+  /**
+   * @param {String}  key               The key in the where clause, either a property of the model, or a logical operator (and/or)
+   * @param {String}  operator          The operator the key is query on (e.g., 'lt', 'gt', 'between', 'eq', 'inq', etc.)
+   * @param {Array}   conditionValue    The condition the operator operates on
+   * @param {Object}  index             Index object
+   */
+  let isIndexed = (key, operator, conditionValue, index) => {
+    if (!index) {
+      return false;
+    } else if (index.rangeKey && index.rangeKey.key == key && ['lt', 'lte', 'gt', 'gte', 'between'].indexOf(operator) != -1) {
+      return true;
+    } else if (index.hashKey.key === key || (index.rangeKey && index.rangeKey.key === key)) {
+      return (operator === 'eq') || (operator === 'inq' && conditionValue.length === 1);
+    }
+  }
+
+  let analyzeWhereObject = (index, whereObject, condition) => {
+    let properties = Object.keys(whereObject);
+    properties.forEach((key) => {
+      let conditionValue = whereObject[key];
+      if (key === 'and') {
+        conditionValue.forEach((whereClause) => {
+          //console.log('and');
+          analyzeWhereObject(index, whereClause, 'AND');
+        });
+      } else if (key === 'or') {
+        conditionValue.forEach((whereClause) => {
+          //console.log('or');
+          analyzeWhereObject(index, whereClause, 'OR');
+        });
+      } else {
+        // TODO
+        //console.log(key);
+        if (Object.prototype.toString.call(conditionValue) == '[object Object]') {
+          // TODO
+        } else {
+          if (isIndexed(key, 'eq', conditionValue, index)) {
+            returnObject.keyQuery[key] = conditionValue;
+          } else {
+            returnObject.filterQuery[key] = conditionValue;
+          }
+        }
+      }
+    });
+  };
+
+  analyzeWhereObject(index, whereObject, operator);
+  console.log(whereObject);
+  console.log(returnObject.keyQuery);
+  console.log(returnObject.filterQuery);
+}
+
+// DynamoDB.prototype.addWhereObjectToConditions = function (params, index, whereObject, operator) {
+//   var properties = Object.keys(whereObject),
+//     me = this;
+//   //For each property in the where condition, decide what to add to the query or scan operation.
+//   properties.forEach(function (conditionKey) {
+//     var whereValue = whereObject[conditionKey];
+//     if (conditionKey === "and") {
+//       whereValue.forEach(function (whereClause) {
+//         me.addWhereObjectToConditions(params, index, whereClause, 'AND');
+//       });
+//     } else if (conditionKey === "or") {
+//       whereValue.forEach(function (whereClause) {
+//         me.addWhereObjectToConditions(params, index, whereClause, 'OR');
+//       });
+//     } else {
+//       me.addConditionToParam(params, index, conditionKey, whereValue, operator || "AND");
+//     }
+
+//   });
+// };
 
 DynamoDB.prototype.runAll = function (model, where, cb) {
   //If no criteria is provided, refuse to perform the costly scan/delete operation.

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -563,29 +563,6 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
     }
   }
 
-  console.log(queryParams);
-
-  if (properties) {
-    //console.log('before: ' + queryParams[1]);
-    let oldParams = {};
-    me.addWhereObjectToConditions(oldParams, index, filter.where);
-    console.log(oldParams);
-    //me.addWhereObjectToConditions(queryParams, index, filter.where);
-    //console.log('after: ' + queryParams[1]);
-    //console.log(queryParams);
-    //me.splitWhere(index, filter.where);
-    
-    // if (!queryParams.KeyConditions) {
-    //   findOperation = "scan";
-    //   console.log('find operation is scan');
-    // }
-  }
-
-
-  // console.log(queryParams);
-  // console.log(queryParams.KeyConditions[0]);
-  //queryParams.KeyConditions = null
-
   if (order && findOperation === "query") {
     if (order[1] === 'ASC') {
       queryParams.ScanIndexForward = true;
@@ -655,8 +632,6 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
       cb();
     });
   }
-
-  //console.log(queryParams);
 
   runQuery(queryParams, function (err) {
     if (err) {
@@ -1315,30 +1290,6 @@ DynamoDB.prototype.whereCanBeQueried = function (whereObject) {
 
 /**
  * @private
- */
-DynamoDB.prototype.addWhereObjectToConditions = function (params, index, whereObject, operator) {
-  var properties = Object.keys(whereObject),
-    me = this;
-  //For each property in the where condition, decide what to add to the query or scan operation.
-  properties.forEach(function (conditionKey) {
-    var whereValue = whereObject[conditionKey];
-    if (conditionKey === "and") {
-      whereValue.forEach(function (whereClause) {
-        me.addWhereObjectToConditions(params, index, whereClause, 'AND');
-      });
-    } else if (conditionKey === "or") {
-      whereValue.forEach(function (whereClause) {
-        me.addWhereObjectToConditions(params, index, whereClause, 'OR');
-      });
-    } else {
-      me.addConditionToParam(params, index, conditionKey, whereValue, operator || "AND");
-    }
-
-  });
-};
-
-/**
- * @private
  *
  */
 DynamoDB.prototype.getIdWhere = function (model, id) {
@@ -1409,7 +1360,7 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
    * @param {String}  conditionValue  The condition that the key operates on
    * return {String}  returnExpression
    */
-  let addExpressionToParam = (params, key, conditionValue) => { // TODO: need to take in params
+  let addExpressionToParam = (params, key, conditionValue) => {
     if (key === "and") {
       throw new Error("And operator not currently supported");
     }
@@ -1453,7 +1404,6 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
       }
     }
 
-
     if (Object.prototype.toString.call(conditionValue) == "[object Object]") {
       let operators = Object.keys(conditionValue);
       operators.forEach((keyValue) => {
@@ -1462,11 +1412,9 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
           case 'inq':
             if (conditionValue[keyValue].length === 1) {
               // we are using index (KeyConditionExpression) here
-              console.log('KeyConditionExpression');
               returnExpression += "(#" + key + " = " + getExpressionValueToken(conditionValue.inq) + ')';
             } else {
               // FilterExpression here
-              console.log('FilterExpression');
               returnExpression += "(#" + key + " IN (" + getExpressionValueToken(conditionValue.inq) + ")" + ")";
             }
             break;
@@ -1543,291 +1491,10 @@ DynamoDB.prototype.generateExpression = (params, queryWhere) => {
         }
       }
     });
-
     return returnExpression;
   }
-
   return analyzeQueryWhere(params, queryWhere);
 }
-
-
-
-/**
- * @private
- * 
- * return an object with Expression, ExpressionAttributeNames, and ExpressionAttributeValues
- */
-DynamoDB.prototype.addExpressionToParam = (key, conditionValue, operator) => { // TODO: need to take in params
-  if (key === "and") {
-    throw new Error("And operator not currently supported");
-  }
-
-  if (key === "or") {
-    throw new Error("Or operator not currently supported");
-  }
-
-  let returnObject = {};
-  returnObject.Expression = "";
-  returnObject.ExpressionAttributeNames = {};
-  returnObject.ExpressionAttributeValues = {};
-
-  let attributeShorthand = "#" + key;
-
-  let prepExpression = () => {
-    if (returnObject.Expression !== "") {
-      returnObject.Expression += " " + operator + " "; // TODO: operator
-    }
-
-    returnObject.ExpressionAttributeNames[attributeShorthand] = key;
-  }
-
-  let getExpressionValueToken = (value) => {
-    if (!util.isArray(value)) {
-      var token = value ? ":" + value.toString().replace(/[^a-zA-Z0-9]/g, "") : ":" + value;
-
-      if (value === "*") {
-        token = ":specialStarParamKey";
-      }
-
-      if (!returnObject.ExpressionAttributeValues[token]) {
-        if (value instanceof Date) {
-          returnObject.ExpressionAttributeValues[token] = value / 1;
-        } else {
-          returnObject.ExpressionAttributeValues[token] = value;
-        }
-      }
-      return token;
-    } else {
-      var tokens = [];
-      value.forEach(function (subValue) {
-        tokens.push(getExpressionValueToken(subValue));
-      });
-      return tokens.join(',');
-    }
-  }
-
-
-  if (Object.prototype.toString.call(conditionValue) == "[object Object]") {
-    let operators = Object.keys(conditionValue);
-    operators.forEach((keyValue) => {
-      //var useIndex = isIndexed(key, keyValue, conditionValue[keyValue], index);
-      prepExpression();
-      switch (keyValue) {
-        case 'inq':
-            returnObject.Expression += "(#" + key + " IN (" + getExpressionValueToken(conditionValue.inq) + ")" + ")";
-          break;
-        case 'gt':
-            returnObject.Expression += "(#" + key + " > " + getExpressionValueToken(conditionValue.gt) + ")";
-          break;
-        case 'gte':
-            returnObject.Expression += "(#" + key + " >= " + getExpressionValueToken(conditionValue.gte) + ")";
-          break;
-        case 'lt':
-            returnObject.Expression += "(#" + key + " < " + getExpressionValueToken(conditionValue.lt) + ")";
-          break;
-        case 'lte':
-            returnObject.Expression += "(#" + key + " <= " + getExpressionValueToken(conditionValue.lte) + ")";
-          break;
-        case 'between':
-            returnObject.Expression += "(#" + key + " BETWEEN " + getExpressionValueToken(conditionValue.between[0]) + " AND " + getExpressionValueToken(conditionValue.between[1]) + ")";
-          break;
-        case 'nin':
-            returnObject.Expression += "NOT " + "(#" + key + " IN (" + getExpressionValueToken(conditionValue.nin) + "))"
-            break;
-        case 'near':
-            throw new Error('near is not supported');
-        case 'neq':
-            returnObject.Expression += "(#" + key + " <> " + getExpressionValueToken(conditionValue.neq) + ")";
-            break;
-        case 'like':
-            returnObject.Expression += "(contains(#" + key + "," + getExpressionValueToken(conditionValue.like) + "))";
-            break;
-        case 'nlike':
-            returnObject.Expression += "(NOT contains(#" + key + "," + getExpressionValueToken(conditionValue.nlike) + "))";
-            break;
-        case 'or':
-        case 'and':
-            throw new Error('and and or conditions are not supported');
-      }
-    });
-  } else {
-    //Simple case -- do equivalency in query/scan notation.
-    prepExpression();
-    returnObject.Expression += "#" + key + " = " + getExpressionValueToken(conditionValue);
-  }
-}
-
-
-
-/**
- * @private
- *
- * @param {Object}    params           The params to the query or scan DynamoDB operation.
- * @param {String}    operation        "scan" or "query"
- * @param {String}    key            The key in the where clause, either a property of the model, or a logical operator.
- * @param {Object|String|Number|String[]|Number[]} Whatever the value is in the logical operation.
- *
- */
-DynamoDB.prototype.addConditionToParam = function (params, index, key, conditionValue, operator) {
-  if (key === "and") {
-    throw new Error("And operator not currently supported");
-  }
-
-  if (key === "or") {
-    throw new Error("Or operator not currently supported");
-  }
-
-  var me = this;
-
-  function isIndexed(key, operator, conditionValue, index) {
-    var useIndex = false;
-    // if key == index.rangeKey and operator in [ eq, lt, lte, gt, gte, between]
-    // OR if key == index.hashKey and (operator is eq OR operator is INQ with set length of 1)
-      // see if rangeKey and supported operator
-    if (!index) {
-      return false;
-    } else if (index.rangeKey && index.rangeKey.key === key &&
-      ['lt', 'lte', 'gt', 'gte', 'between'].indexOf(operator) != -1) {
-      useIndex = true;
-    } else if (index.hashKey.key === key || (index.rangeKey && index.rangeKey.key === key)) {
-      useIndex = (operator === 'eq') || (operator === 'inq' && conditionValue.length === 1);
-    }
-    return useIndex;
-  }
-
-  var attributeShorthand = "#" + key;
-
-  function prepFilterExpression() {
-    if (!params.FilterExpression) {
-      params.FilterExpression = "";
-    }
-    if (params.FilterExpression !== "") {
-      params.FilterExpression += " " + operator + " ";
-    }
-
-    params.ExpressionAttributeNames = params.ExpressionAttributeNames || {};
-    params.ExpressionAttributeValues = params.ExpressionAttributeValues || {};
-    params.ExpressionAttributeNames[attributeShorthand] = key;
-  }
-
-  function addKeyCondition(key, operator, value, value2) {
-    params.KeyConditions = params.KeyConditions || [];
-    params.KeyConditions.push(me.client.Condition(key, operator, value, value2));
-  }
-
-  function getExpressionValueToken(value) {
-    if (!util.isArray(value)) {
-      var token = value ? ":" + value.toString().replace(/[^a-zA-Z0-9]/g, "") : ":" + value;
-
-      if (value === "*") {
-        token = ":specialStarParamKey";
-      }
-
-      if (!params.ExpressionAttributeValues[token]) {
-        if (value instanceof Date) {
-          params.ExpressionAttributeValues[token] = value / 1;
-        } else {
-          params.ExpressionAttributeValues[token] = value;
-        }
-      }
-      return token;
-    } else {
-      var tokens = [];
-      value.forEach(function (subValue) {
-        tokens.push(getExpressionValueToken(subValue));
-      });
-      return tokens.join(',');
-    }
-  }
-
-  //The where definition is a complex and not just an equivalancy operation.
-  if (Object.prototype.toString.call(conditionValue) == "[object Object]") {
-    var operators = Object.keys(conditionValue);
-    operators.forEach(function (keyValue) {
-      var useIndex = isIndexed(key, keyValue, conditionValue[keyValue], index);
-      switch (keyValue) {
-      case 'inq':
-        if (useIndex) {
-          addKeyCondition(key, "EQ", conditionValue.inq[0]);
-        } else {
-          prepFilterExpression();
-          params.FilterExpression += "(#" + key + " IN (" + getExpressionValueToken(conditionValue.inq) + ")" + ")";
-        }
-        break;
-      case 'gt':
-        if (useIndex) {
-          addKeyCondition(key, "GT", conditionValue.gt);
-        } else {
-          prepFilterExpression();
-          params.FilterExpression += "(#" + key + " > " + getExpressionValueToken(conditionValue.gt) + ")";
-        }
-        break;
-      case 'gte':
-        if (useIndex) {
-          addKeyCondition(key, "GE", conditionValue.gte);
-        } else {
-          prepFilterExpression();
-          params.FilterExpression += "(#" + key + " >= " + getExpressionValueToken(conditionValue.gte) + ")";
-        }
-        break;
-      case 'lt':
-        if (useIndex) {
-          addKeyCondition(key, "LT", conditionValue.lt);
-        } else {
-          prepFilterExpression();
-          params.FilterExpression += "(#" + key + " < " + getExpressionValueToken(conditionValue.lt) + ")";
-        }
-        break;
-      case 'lte':
-        if (useIndex) {
-          addKeyCondition(key, "LE", conditionValue.lte);
-        } else {
-          prepFilterExpression();
-          params.FilterExpression += "(#" + key + " <= " + getExpressionValueToken(conditionValue.lte) + ")";
-        }
-        break;
-      case 'between':
-        if (useIndex) {
-          addKeyCondition(key, "BETWEEN", conditionValue.between[0], conditionValue.between[1]);
-        } else {
-          prepFilterExpression();
-          params.FilterExpression += "(#" + key + " BETWEEN " + getExpressionValueToken(conditionValue.between[0]) + " AND " + getExpressionValueToken(conditionValue.between[1]) + ")";
-        }
-        break;
-      case 'nin':
-        prepFilterExpression();
-        params.FilterExpression += "NOT " + "(#" + key + " IN (" + getExpressionValueToken(conditionValue.nin) + "))"
-        break;
-      case 'near':
-        throw new Error('near is not supported');
-        break;
-      case 'neq':
-        prepFilterExpression();
-        params.FilterExpression += "(#" + key + " <> " + getExpressionValueToken(conditionValue.neq) + ")";
-        break;
-      case 'like':
-        prepFilterExpression();
-        params.FilterExpression += "(contains(#" + key + "," + getExpressionValueToken(conditionValue.like) + "))";
-        break;
-      case 'nlike':
-        prepFilterExpression();
-        params.FilterExpression += "(NOT contains(#" + key + "," + getExpressionValueToken(conditionValue.nlike) + "))";
-        break;
-      case 'or':
-      case 'and':
-        throw new Error('and and or conditions are not supported');
-      }
-    });
-  } else {
-    //Simple case -- do equivalency in query/scan notation.
-    if (isIndexed(key, "eq", conditionValue, index)) {
-      addKeyCondition(key, "EQ", conditionValue);
-    } else {
-      prepFilterExpression();
-      params.FilterExpression += "#" + key + " = " + getExpressionValueToken(conditionValue);
-    }
-  }
-};
 
 function parameterizePath(path) {
   var pieces = path.split(".");

--- a/lib/dynamodb.js
+++ b/lib/dynamodb.js
@@ -688,6 +688,7 @@ DynamoDB.prototype.all = function all(model, filter, cb) {
 DynamoDB.prototype.splitWhere = (index, whereObject, operator) => {
   let returnObject = {};
   returnObject.keyQuery = {};
+  //console.log("returnObject.keyQuery is " + returnObject.keyQuery);
   returnObject.filterQuery = {};
 
   /**
@@ -710,21 +711,56 @@ DynamoDB.prototype.splitWhere = (index, whereObject, operator) => {
     let properties = Object.keys(whereObject);
     properties.forEach((key) => {
       let conditionValue = whereObject[key];
-      if (key === 'and') {
-        conditionValue.forEach((whereClause) => {
-          //console.log('and');
-          analyzeWhereObject(index, whereClause, 'AND');
-        });
-      } else if (key === 'or') {
-        conditionValue.forEach((whereClause) => {
-          //console.log('or');
-          analyzeWhereObject(index, whereClause, 'OR');
-        });
-      } else {
+      // if (key === 'and') {
+      //   conditionValue.forEach((whereClause) => {
+      //     //console.log('and');
+      //     analyzeWhereObject(index, whereClause, 'AND');
+      //   });
+      // } else if (key === 'or') {
+      //   conditionValue.forEach((whereClause) => {
+      //     //console.log('or');
+      //     analyzeWhereObject(index, whereClause, 'OR');
+      //   });
+      // } else {
         // TODO
         //console.log(key);
         if (Object.prototype.toString.call(conditionValue) == '[object Object]') {
           // TODO
+          let operators = Object.keys(conditionValue);
+          operators.forEach((operator) => {
+            if (isIndexed(key, operator, conditionValue[operator], index)) {
+              // // if (!returnObject.keyQuery[key]) {
+              // //   console.log("key is null");
+              // //   returnObject.keyQuery[key] = {};
+              // //   console.log("returnObject.keyQuery[key] is " + returnObject.keyQuery.key);
+              // // }
+              // returnObject.keyQuery[key] = returnObject.keyQuery[key] || {};
+              // console.log("returnObject.keyQuery[key] is " + returnObject.keyQuery.key);
+
+              // console.log("key is " + key);
+              // console.log("operator is " + operator);
+              // console.log("condtionValue is " + conditionValue);
+              // console.log("conditionValue[operator] is " + conditionValue[operator]);
+              // //returnObject.keyQuery[key].operator = conditionValue;
+              // //returnObject.keyQuery.key[operator] = conditionValue;
+              // returnObject.keyQuery[key] = 
+              // //returnObject.keyQuery.key.operator = "hello";
+
+              if (!returnObject.keyQuery[key]) {
+                returnObject.keyQuery[key] = { [operator]: conditionValue[operator] };
+              } else {
+                returnObject.keyQuery[key][operator] = conditionValue[operator];
+              }
+            } else {
+              if (!returnObject.filterQuery[key]) {
+                returnObject.filterQuery[key] = { [operator]: conditionValue[operator] };
+              } else {
+                returnObject.filterQuery[key][operator] = conditionValue[operator];
+              }
+
+              //returnObject.filterQuery.key.operator = conditionValue;
+            }
+          })
         } else {
           if (isIndexed(key, 'eq', conditionValue, index)) {
             returnObject.keyQuery[key] = conditionValue;
@@ -732,7 +768,8 @@ DynamoDB.prototype.splitWhere = (index, whereObject, operator) => {
             returnObject.filterQuery[key] = conditionValue;
           }
         }
-      }
+    //   }
+    // });
     });
   };
 

--- a/test/README.md
+++ b/test/README.md
@@ -26,3 +26,9 @@ Here is a sample configuration block, as well as a sample credentials block.
 If you use nodeinspector, this is a handy command to run from the test directory.
 
 node-debug ./../node_modules/.bin/_mocha -G --timeout 10000 *.test.js
+
+### splitWhere and generateExpression tests
+To test `splitWhere` and `generateExpression`:
+```
+mocha expression.js
+```

--- a/test/expression.js
+++ b/test/expression.js
@@ -1,10 +1,7 @@
 'use strict';
 
-var should = require('./init.js');
 const assert = require('assert');
-const path = require('path');
 const dynamodb = require('../lib/dynamodb.js');
-const DataSource = require('loopback-datasource-juggler').DataSource;
 
 const index1 = {
   name: 'Test-playerId-born-index1',
@@ -23,43 +20,95 @@ const where1 = {
       { lastName: 'Beckham' }
     ]}
   ]
-}
+};
 
-var config = require('rc')('loopback', {test: {dynamodb: {
-    region: 'local',
-    credentials: 'file',
-    credfile: path.join(__dirname, 'credentials.json'),
-    endpoint: 'http://localhost:8080'
-}}}).test.dynamodb;
+const where2 = {
+  or: [
+    { and: [
+      { key1: 1 },
+      { key2: 2 },
+      { or: [
+        { key3: 3 },
+        { key4: 4 }
+      ]},
+      { key5: 5 }
+    ]},
+    { and: [
+      { or: [
+        { key6: 6 },
+        { key7: 7 }
+      ]},
+      { key8: 8 }
+    ]}
+  ]
+};
 
-describe('Test', () => {
-  describe('sub 1', () => {
-    it('should pass', () => {
-      assert.equal(5, 5);
-    });
+const obj = dynamodb.DynamoDB.prototype.splitWhere(index1, where1);
 
-    it('lets try this', () => {
-      // console.log(dynamodb.initialize);
-      // let what = dynamodb.DynamoDB;
-      // console.log(what);
-      // let obj = dynamodb.splitWhere(index1, where1);
-      //dynamodb.test();
-      //test();
-      // let myDynamodb = dynamodb.initialize({});
-      // console.log(myDynamodb);
-      // var ds = new DataSource(require('../'), config);
-      // dynamodb.initialize(ds, () => {
-      //   let obj = ds.connector.splitWhere(index1, where1);
-      //   console.log(obj.keyQuery);
-      //   assert.notEqual(obj, null);
-      // });
+describe('Testing splitWhere', () => {
+  it('should return object with keyQuery', () => {
+    assert.notEqual(obj.keyQuery, null);
+  });
 
-      let obj = dynamodb.DynamoDB.prototype.splitWhere(index1, where1);
-      console.log(obj.keyQuery);
+  it('should return object with filterQuery', () => {
+    assert.notEqual(obj.filterQuery, null);
+  });
 
-      // let obj = DynamoDB.prototype.splitWhere(index1, where1);
-      
-      // assert.notEqual(obj, null);
-    });
+  it('keyQuery should have the whereObject for keys', () => {
+    assert.equal(obj.keyQuery.playerId, 1);
+    assert.equal(obj.keyQuery.born.between[0], 100);
+    assert.equal(obj.keyQuery.born.between[1], 200);
+  });
+
+  it('filterQuery should have the whereObject for filter', () => {
+    assert.equal(obj.filterQuery.or.length, 3);
+    assert.equal(obj.filterQuery.or[0].height.between[0], 68);
+    assert.equal(obj.filterQuery.or[1].weight.lt, 88);
+    assert.equal(obj.filterQuery.or[2].and[0].team, 'Giants');
+    assert.equal(obj.filterQuery.or[2].and[1].lastName, 'Beckham');
+  })
+});
+
+describe('Testing generateExpression', () => {
+  let params = {};
+  let keyConditionExpression = dynamodb.DynamoDB.prototype.generateExpression(params, obj.keyQuery);
+  let filterExpression = dynamodb.DynamoDB.prototype.generateExpression(params, obj.filterQuery);
+
+  it('should have correct KeyConditionExpression chained with AND', () => {
+    assert.equal(keyConditionExpression, '(#playerId = :1) AND (#born BETWEEN :100 AND :200)');
+  });
+
+  it('should have correct FilterExpression chained with AND and OR', () => {
+    assert.equal(filterExpression, '((#height BETWEEN :68 AND :75) OR (#weight < :88) OR ((#team = :Giants) AND (#lastName = :Beckham)))');
+  });
+
+  it('should have coorect ExpressionAttributeNames with #', () => {
+    assert.equal(params.ExpressionAttributeNames['#playerId'], 'playerId');
+    assert.equal(params.ExpressionAttributeNames['#born'], 'born');
+    assert.equal(params.ExpressionAttributeNames['#height'], 'height');
+    assert.equal(params.ExpressionAttributeNames['#weight'], 'weight');
+    assert.equal(params.ExpressionAttributeNames['#team'], 'team');
+    assert.equal(params.ExpressionAttributeNames['#lastName'], 'lastName');
+  });
+
+  it('should have correct ExpressionAttributeValues with :', () => {
+    assert.equal(params.ExpressionAttributeValues[':1'], 1);
+    assert.equal(params.ExpressionAttributeValues[':100'], 100);
+    assert.equal(params.ExpressionAttributeValues[':200'], 200);
+    assert.equal(params.ExpressionAttributeValues[':68'], 68);
+    assert.equal(params.ExpressionAttributeValues[':75'], 75);
+    assert.equal(params.ExpressionAttributeValues[':88'], 88);
+    assert.equal(params.ExpressionAttributeValues[':Giants'], 'Giants');
+    assert.equal(params.ExpressionAttributeValues[':Beckham'], 'Beckham');
+  });
+
+});
+
+describe('Testing whereObject with complex AND/OR', () => {
+  let params = {};
+  let expression = dynamodb.DynamoDB.prototype.generateExpression(params, where2);
+
+  it('should generate correct Expression with complex AND/OR logic', () => {
+    assert.equal(expression, '(((#key1 = :1) AND (#key2 = :2) AND ((#key3 = :3) OR (#key4 = :4)) AND (#key5 = :5)) OR (((#key6 = :6) OR (#key7 = :7)) AND (#key8 = :8)))');
   });
 });

--- a/test/expression.js
+++ b/test/expression.js
@@ -1,15 +1,15 @@
 'use strict';
 
-const assert = require('assert');
-const dynamodb = require('../lib/dynamodb.js');
+var assert = require('assert');
+var dynamodb = require('../lib/dynamodb.js');
 
-const index1 = {
+var index1 = {
   name: 'Test-playerId-born-index1',
   hashKey: { key: 'playerId', type: 'N' },
   rangeKey: { key: 'born', type: 'N' }
 };
 
-const where1 = {
+var where1 = {
   playerId: 1,
   born: { between: [ 100, 200 ]},
   or: [
@@ -22,7 +22,7 @@ const where1 = {
   ]
 };
 
-const where2 = {
+var where2 = {
   or: [
     { and: [
       { key1: 1 },
@@ -43,24 +43,24 @@ const where2 = {
   ]
 };
 
-const obj = dynamodb.DynamoDB.prototype.splitWhere(index1, where1);
+var obj = dynamodb.DynamoDB.prototype.splitWhere(index1, where1);
 
-describe('Testing splitWhere', () => {
-  it('should return object with keyQuery', () => {
+describe('Testing splitWhere', function () {
+  it('should return object with keyQuery', function () {
     assert.notEqual(obj.keyQuery, null);
   });
 
-  it('should return object with filterQuery', () => {
+  it('should return object with filterQuery', function () {
     assert.notEqual(obj.filterQuery, null);
   });
 
-  it('keyQuery should have the whereObject for keys', () => {
+  it('keyQuery should have the whereObject for keys', function () {
     assert.equal(obj.keyQuery.playerId, 1);
     assert.equal(obj.keyQuery.born.between[0], 100);
     assert.equal(obj.keyQuery.born.between[1], 200);
   });
 
-  it('filterQuery should have the whereObject for filter', () => {
+  it('filterQuery should have the whereObject for filter', function () {
     assert.equal(obj.filterQuery.or.length, 3);
     assert.equal(obj.filterQuery.or[0].height.between[0], 68);
     assert.equal(obj.filterQuery.or[1].weight.lt, 88);
@@ -69,31 +69,31 @@ describe('Testing splitWhere', () => {
   })
 });
 
-describe('Testing convertWhereObjectToAndArray', () => {
-  let andArray = dynamodb.DynamoDB.prototype.convertWhereObjectToAndArray(where1);
+describe('Testing convertWhereObjectToAndArray', function () {
+  var andArray = dynamodb.DynamoDB.prototype.convertWhereObjectToAndArray(where1);
 
-  it('return andArray should have same properties as whereObject', () => {
-    andArray.forEach((ele) => {
-      let key = Object.keys(ele)[0];
+  it('return andArray should have same properties as whereObject', function () {
+    andArray.forEach(function (ele) {
+      var key = Object.keys(ele)[0];
       assert.equal(ele[key], where1[key]);
     });
   });
 });
 
-describe('Testing generateExpression', () => {
-  let params = {};
-  let keyConditionExpression = dynamodb.DynamoDB.prototype.generateExpression(params, dynamodb.DynamoDB.prototype.convertWhereObjectToAndArray(obj.keyQuery));
-  let filterExpression = dynamodb.DynamoDB.prototype.generateExpression(params, dynamodb.DynamoDB.prototype.convertWhereObjectToAndArray(obj.filterQuery));
+describe('Testing generateExpression', function () {
+  var params = {};
+  var keyConditionExpression = dynamodb.DynamoDB.prototype.generateExpression(params, dynamodb.DynamoDB.prototype.convertWhereObjectToAndArray(obj.keyQuery));
+  var filterExpression = dynamodb.DynamoDB.prototype.generateExpression(params, dynamodb.DynamoDB.prototype.convertWhereObjectToAndArray(obj.filterQuery));
 
-  it('should have correct KeyConditionExpression chained with AND', () => {
+  it('should have correct KeyConditionExpression chained with AND', function () {
     assert.equal(keyConditionExpression, '((#playerId = :1) AND (#born BETWEEN :100 AND :200))');
   });
 
-  it('should have correct FilterExpression chained with AND and OR', () => {
+  it('should have correct FilterExpression chained with AND and OR', function () {
     assert.equal(filterExpression, '((#height BETWEEN :68 AND :75) OR (#weight < :88) OR ((#team = :Giants) AND (#lastName = :Beckham)))');
   });
 
-  it('should have correct ExpressionAttributeNames with #', () => {
+  it('should have correct ExpressionAttributeNames with #', function () {
     assert.equal(params.ExpressionAttributeNames['#playerId'], 'playerId');
     assert.equal(params.ExpressionAttributeNames['#born'], 'born');
     assert.equal(params.ExpressionAttributeNames['#height'], 'height');
@@ -102,7 +102,7 @@ describe('Testing generateExpression', () => {
     assert.equal(params.ExpressionAttributeNames['#lastName'], 'lastName');
   });
 
-  it('should have correct ExpressionAttributeValues with :', () => {
+  it('should have correct ExpressionAttributeValues with :', function () {
     assert.equal(params.ExpressionAttributeValues[':1'], 1);
     assert.equal(params.ExpressionAttributeValues[':100'], 100);
     assert.equal(params.ExpressionAttributeValues[':200'], 200);
@@ -115,11 +115,11 @@ describe('Testing generateExpression', () => {
 
 });
 
-describe('Testing whereObject with complex AND/OR', () => {
-  let params = {};
-  let expression = dynamodb.DynamoDB.prototype.generateExpression(params, dynamodb.DynamoDB.prototype.convertWhereObjectToAndArray(where2));
+describe('Testing whereObject with complex AND/OR', function () {
+  var params = {};
+  var expression = dynamodb.DynamoDB.prototype.generateExpression(params, dynamodb.DynamoDB.prototype.convertWhereObjectToAndArray(where2));
 
-  it('should generate correct Expression with complex AND/OR logic', () => {
+  it('should generate correct Expression with complex AND/OR logic', function () {
     assert.equal(expression, '(((#key1 = :1) AND (#key2 = :2) AND ((#key3 = :3) OR (#key4 = :4)) AND (#key5 = :5)) OR (((#key6 = :6) OR (#key7 = :7)) AND (#key8 = :8)))');
   });
 });

--- a/test/expression.js
+++ b/test/expression.js
@@ -69,13 +69,24 @@ describe('Testing splitWhere', () => {
   })
 });
 
+describe('Testing convertWhereObjectToAndArray', () => {
+  let andArray = dynamodb.DynamoDB.prototype.convertWhereObjectToAndArray(where1);
+
+  it('return andArray should have same properties as whereObject', () => {
+    andArray.forEach((ele) => {
+      let key = Object.keys(ele)[0];
+      assert.equal(ele[key], where1[key]);
+    });
+  });
+});
+
 describe('Testing generateExpression', () => {
   let params = {};
-  let keyConditionExpression = dynamodb.DynamoDB.prototype.generateExpression(params, obj.keyQuery);
-  let filterExpression = dynamodb.DynamoDB.prototype.generateExpression(params, obj.filterQuery);
+  let keyConditionExpression = dynamodb.DynamoDB.prototype.generateExpression(params, dynamodb.DynamoDB.prototype.convertWhereObjectToAndArray(obj.keyQuery));
+  let filterExpression = dynamodb.DynamoDB.prototype.generateExpression(params, dynamodb.DynamoDB.prototype.convertWhereObjectToAndArray(obj.filterQuery));
 
   it('should have correct KeyConditionExpression chained with AND', () => {
-    assert.equal(keyConditionExpression, '(#playerId = :1) AND (#born BETWEEN :100 AND :200)');
+    assert.equal(keyConditionExpression, '((#playerId = :1) AND (#born BETWEEN :100 AND :200))');
   });
 
   it('should have correct FilterExpression chained with AND and OR', () => {
@@ -106,7 +117,7 @@ describe('Testing generateExpression', () => {
 
 describe('Testing whereObject with complex AND/OR', () => {
   let params = {};
-  let expression = dynamodb.DynamoDB.prototype.generateExpression(params, where2);
+  let expression = dynamodb.DynamoDB.prototype.generateExpression(params, dynamodb.DynamoDB.prototype.convertWhereObjectToAndArray(where2));
 
   it('should generate correct Expression with complex AND/OR logic', () => {
     assert.equal(expression, '(((#key1 = :1) AND (#key2 = :2) AND ((#key3 = :3) OR (#key4 = :4)) AND (#key5 = :5)) OR (((#key6 = :6) OR (#key7 = :7)) AND (#key8 = :8)))');

--- a/test/expression.js
+++ b/test/expression.js
@@ -82,7 +82,7 @@ describe('Testing generateExpression', () => {
     assert.equal(filterExpression, '((#height BETWEEN :68 AND :75) OR (#weight < :88) OR ((#team = :Giants) AND (#lastName = :Beckham)))');
   });
 
-  it('should have coorect ExpressionAttributeNames with #', () => {
+  it('should have correct ExpressionAttributeNames with #', () => {
     assert.equal(params.ExpressionAttributeNames['#playerId'], 'playerId');
     assert.equal(params.ExpressionAttributeNames['#born'], 'born');
     assert.equal(params.ExpressionAttributeNames['#height'], 'height');

--- a/test/expression.js
+++ b/test/expression.js
@@ -1,0 +1,65 @@
+'use strict';
+
+var should = require('./init.js');
+const assert = require('assert');
+const path = require('path');
+const dynamodb = require('../lib/dynamodb.js');
+const DataSource = require('loopback-datasource-juggler').DataSource;
+
+const index1 = {
+  name: 'Test-playerId-born-index1',
+  hashKey: { key: 'playerId', type: 'N' },
+  rangeKey: { key: 'born', type: 'N' }
+};
+
+const where1 = {
+  playerId: 1,
+  born: { between: [ 100, 200 ]},
+  or: [
+    { height: { between: [ 68, 75 ]}},
+    { weight: { lt: 88 }},
+    { and: [
+      { team: 'Giants'},
+      { lastName: 'Beckham' }
+    ]}
+  ]
+}
+
+var config = require('rc')('loopback', {test: {dynamodb: {
+    region: 'local',
+    credentials: 'file',
+    credfile: path.join(__dirname, 'credentials.json'),
+    endpoint: 'http://localhost:8080'
+}}}).test.dynamodb;
+
+describe('Test', () => {
+  describe('sub 1', () => {
+    it('should pass', () => {
+      assert.equal(5, 5);
+    });
+
+    it('lets try this', () => {
+      // console.log(dynamodb.initialize);
+      // let what = dynamodb.DynamoDB;
+      // console.log(what);
+      // let obj = dynamodb.splitWhere(index1, where1);
+      //dynamodb.test();
+      //test();
+      // let myDynamodb = dynamodb.initialize({});
+      // console.log(myDynamodb);
+      // var ds = new DataSource(require('../'), config);
+      // dynamodb.initialize(ds, () => {
+      //   let obj = ds.connector.splitWhere(index1, where1);
+      //   console.log(obj.keyQuery);
+      //   assert.notEqual(obj, null);
+      // });
+
+      let obj = dynamodb.DynamoDB.prototype.splitWhere(index1, where1);
+      console.log(obj.keyQuery);
+
+      // let obj = DynamoDB.prototype.splitWhere(index1, where1);
+      
+      // assert.notEqual(obj, null);
+    });
+  });
+});


### PR DESCRIPTION
- Promote top level `AND`
- Split `filter.where` into two where objects, `keyQuery` and `filterQuery`, to be used to generate `KeyConditionExpression` and `FilterExpression`
- Implement generic `generateExpression()` to generate `KeyConditionExpression` and `FilterExpression`, along with `ExpressionAttributeNames` and `ExpressionAttributeValues`
- Use newer attributes instead of legacy attributes (e.g. `KeyConditionExpression` instead of `KeyConditions`, `ProjectionExpression` instead of `AttributesToGet`, etc.)
- Fix bug with more complex `AND` and `OR` logic
